### PR TITLE
adding support for token_endpoint_auth_method

### DIFF
--- a/api/v1alpha1/oauth2client_types.go
+++ b/api/v1alpha1/oauth2client_types.go
@@ -100,6 +100,11 @@ type OAuth2ClientSpec struct {
 	// HydraAdmin is the optional configuration to use for managing
 	// this client
 	HydraAdmin HydraAdmin `json:"hydraAdmin,omitempty"`
+
+	// +kubebuilder:validation:Enum=;client_secret_basic;client_secret_post;private_key_jwt;none
+	//
+	// Indication which authenticaiton method shoud be used for the token endpoint
+	TokenEndpointAuthMethod TokenEndpointAuthMethod `json:"tokenEndpointAuthMethod,omitempty"`
 }
 
 // +kubebuilder:validation:Enum=client_credentials;authorization_code;implicit;refresh_token
@@ -113,6 +118,10 @@ type ResponseType string
 // +kubebuilder:validation:Pattern=\w+:/?/?[^\s]+
 // RedirectURI represents a redirect URI for the client
 type RedirectURI string
+
+// +kubebuilder:validation:Enum=;client_secret_basic;client_secret_post;private_key_jwt;none
+// TokenEndpointAuthMethod represents an authenticaiton method for token endpoint
+type TokenEndpointAuthMethod string
 
 // OAuth2ClientStatus defines the observed state of OAuth2Client
 type OAuth2ClientStatus struct {
@@ -157,11 +166,12 @@ func init() {
 // ToOAuth2ClientJSON converts an OAuth2Client into a OAuth2ClientJSON object that represents an OAuth2 client digestible by ORY Hydra
 func (c *OAuth2Client) ToOAuth2ClientJSON() *hydra.OAuth2ClientJSON {
 	return &hydra.OAuth2ClientJSON{
-		GrantTypes:    grantToStringSlice(c.Spec.GrantTypes),
-		ResponseTypes: responseToStringSlice(c.Spec.ResponseTypes),
-		RedirectURIs:  redirectToStringSlice(c.Spec.RedirectURIs),
-		Scope:         c.Spec.Scope,
-		Owner:         fmt.Sprintf("%s/%s", c.Name, c.Namespace),
+		GrantTypes:              grantToStringSlice(c.Spec.GrantTypes),
+		ResponseTypes:           responseToStringSlice(c.Spec.ResponseTypes),
+		RedirectURIs:            redirectToStringSlice(c.Spec.RedirectURIs),
+		Scope:                   c.Spec.Scope,
+		Owner:                   fmt.Sprintf("%s/%s", c.Name, c.Namespace),
+		TokenEndpointAuthMethod: string(c.Spec.TokenEndpointAuthMethod),
 	}
 }
 

--- a/config/crd/bases/hydra.ory.sh_oauth2clients.yaml
+++ b/config/crd/bases/hydra.ory.sh_oauth2clients.yaml
@@ -449,6 +449,14 @@ spec:
               maxItems: 3
               minItems: 1
               type: array
+            tokenEndpointAuthMethod:
+              description: Indication which authenticaiton method shoud be used for the token endpoint.
+              type: string
+              enum:
+              - client_secret_basic
+              - client_secret_post
+              - private_key_jwt
+              - none
             scope:
               description: Scope is a string containing a space-separated list of
                 scope values (as described in Section 3.3 of OAuth 2.0 [RFC6749])

--- a/config/samples/hydra_v1alpha1_oauth2client.yaml
+++ b/config/samples/hydra_v1alpha1_oauth2client.yaml
@@ -13,9 +13,6 @@ spec:
     - id_token
     - code
     - token
-  redirectUris:
-    - https://client/account
-    - http://localhost:8080
   scope: "read write"
   secretName: my-secret-123
   # these are optional
@@ -29,4 +26,5 @@ spec:
     port: 4445
     endpoint: /clients
     forwardedProto: https
+  tokenEndpointAuthMethod: client_secret_basic
   

--- a/config/samples/hydra_v1alpha1_oauth2client_user_credentials.yaml
+++ b/config/samples/hydra_v1alpha1_oauth2client_user_credentials.yaml
@@ -36,3 +36,4 @@ spec:
     port: 4445
     endpoint: /clients
     forwardedProto: https
+  tokenEndpointAuthMethod: client_secret_basic

--- a/hydra/types.go
+++ b/hydra/types.go
@@ -4,13 +4,14 @@ import "k8s.io/utils/pointer"
 
 // OAuth2ClientJSON represents an OAuth2 client digestible by ORY Hydra
 type OAuth2ClientJSON struct {
-	ClientID      *string  `json:"client_id,omitempty"`
-	Secret        *string  `json:"client_secret,omitempty"`
-	GrantTypes    []string `json:"grant_types"`
-	RedirectURIs  []string `json:"redirect_uris,omitempty"`
-	ResponseTypes []string `json:"response_types,omitempty"`
-	Scope         string   `json:"scope"`
-	Owner         string   `json:"owner"`
+	ClientID                *string  `json:"client_id,omitempty"`
+	Secret                  *string  `json:"client_secret,omitempty"`
+	GrantTypes              []string `json:"grant_types"`
+	RedirectURIs            []string `json:"redirect_uris,omitempty"`
+	ResponseTypes           []string `json:"response_types,omitempty"`
+	Scope                   string   `json:"scope"`
+	Owner                   string   `json:"owner"`
+	TokenEndpointAuthMethod string   `json:"token_endpoint_auth_method,omitempty"`
 }
 
 // Oauth2ClientCredentials represents client ID and password fetched from a Kubernetes secret


### PR DESCRIPTION
in some cases default client_secret_basic auth method is not suitable. 

Therefor it would be useful to expose token_endpoint_auth_method hydra API parameter to maester CRD