### PR TITLE
adding support for hydra client metadata property

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -76,11 +76,17 @@ jobs:
        sudo echo "export PATH=$PATH:/usr/local/kubebuilder/bin" >> $HOME/.profile
 
    - run:
-      name: Install ginkgo,controller-gen, kustomize
+      name: Install kustomize
+      command: |
+        curl -sL https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize%2Fv3.3.0/kustomize_v3.3.0_linux_amd64.tar.gz | tar -xz -C /tmp/
+        sudo mv /tmp/kustomize /usr/local/bin/kustomize
+        kustomize version
+
+   - run:
+      name: Install ginkgo,controller-gen
       command: |
        go get github.com/onsi/ginkgo/ginkgo
        go get sigs.k8s.io/controller-tools/cmd/controller-gen@v0.2.0-beta.2
-       go install sigs.k8s.io/kustomize/kustomize/v3
 
    - run:
       name: Install Kind

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 **Table of Contents**  *generated with [DocToc](https://github.com/thlorenz/doctoc)*
 
 - [Changelog](#changelog)
+  - [v0.0.7 (2019-12-16)](#v007-2019-12-16)
   - [v0.0.6 (2019-11-26)](#v006-2019-11-26)
   - [v0.0.5 (2019-11-14)](#v005-2019-11-14)
   - [v0.0.4 (2019-09-19)](#v004-2019-09-19)
@@ -15,6 +16,14 @@
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
 
 # Changelog
+
+## [v0.0.7](https://github.com/ory/hydra-maester/tree/v0.0.7) (2019-12-16)
+
+[Full Changelog](https://github.com/ory/hydra-maester/compare/v0.0.6...v0.0.7)
+
+**Merged pull requests:**
+
+- Set OwnerReference on Secrets created by controller [\#39](https://github.com/ory/hydra-maester/pull/39) ([kubadz](https://github.com/kubadz))
 
 ## [v0.0.6](https://github.com/ory/hydra-maester/tree/v0.0.6) (2019-11-26)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 **Table of Contents**  *generated with [DocToc](https://github.com/thlorenz/doctoc)*
 
 - [Changelog](#changelog)
+  - [v0.0.9 (2019-12-26)](#v009-2019-12-26)
+  - [v0.0.8 (2019-12-16)](#v008-2019-12-16)
   - [v0.0.7 (2019-12-16)](#v007-2019-12-16)
   - [v0.0.6 (2019-11-26)](#v006-2019-11-26)
   - [v0.0.5 (2019-11-14)](#v005-2019-11-14)
@@ -16,6 +18,22 @@
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
 
 # Changelog
+
+## [v0.0.9](https://github.com/ory/hydra-maester/tree/v0.0.9) (2019-12-26)
+
+[Full Changelog](https://github.com/ory/hydra-maester/compare/v0.0.8...v0.0.9)
+
+**Closed issues:**
+
+- Set owner reference on secrets created by the controller. [\#20](https://github.com/ory/hydra-maester/issues/20)
+
+**Merged pull requests:**
+
+- Use binary kustomize release for CI [\#40](https://github.com/ory/hydra-maester/pull/40) ([aeneasr](https://github.com/aeneasr))
+
+## [v0.0.8](https://github.com/ory/hydra-maester/tree/v0.0.8) (2019-12-16)
+
+[Full Changelog](https://github.com/ory/hydra-maester/compare/v0.0.7...v0.0.8)
 
 ## [v0.0.7](https://github.com/ory/hydra-maester/tree/v0.0.7) (2019-12-16)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 **Table of Contents**  *generated with [DocToc](https://github.com/thlorenz/doctoc)*
 
 - [Changelog](#changelog)
+  - [v0.0.10 (2020-02-01)](#v0010-2020-02-01)
   - [v0.0.9 (2019-12-26)](#v009-2019-12-26)
   - [v0.0.8 (2019-12-16)](#v008-2019-12-16)
   - [v0.0.7 (2019-12-16)](#v007-2019-12-16)
@@ -18,6 +19,19 @@
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
 
 # Changelog
+
+## [v0.0.10](https://github.com/ory/hydra-maester/tree/v0.0.10) (2020-02-01)
+
+[Full Changelog](https://github.com/ory/hydra-maester/compare/v0.0.9...v0.0.10)
+
+**Closed issues:**
+
+- hydra\_v1alpha1\_oauth2client\_user\_credentials.yaml is using invalid apiVersion for OAuth2Client [\#41](https://github.com/ory/hydra-maester/issues/41)
+
+**Merged pull requests:**
+
+- adding audience into API calls [\#44](https://github.com/ory/hydra-maester/pull/44) ([amihalj](https://github.com/amihalj))
+- Fix sample apiVersion [\#42](https://github.com/ory/hydra-maester/pull/42) ([PoulpiFr](https://github.com/PoulpiFr))
 
 ## [v0.0.9](https://github.com/ory/hydra-maester/tree/v0.0.9) (2019-12-26)
 

--- a/api/v1alpha1/oauth2client_types.go
+++ b/api/v1alpha1/oauth2client_types.go
@@ -126,6 +126,7 @@ type RedirectURI string
 // TokenEndpointAuthMethod represents an authentication method for token endpoint
 type TokenEndpointAuthMethod string
 
+// Metadata is abritrary data
 type Metadata map[string]interface{}
 
 // OAuth2ClientStatus defines the observed state of OAuth2Client
@@ -177,6 +178,7 @@ func (c *OAuth2Client) ToOAuth2ClientJSON() *hydra.OAuth2ClientJSON {
 		Scope:                   c.Spec.Scope,
 		Owner:                   fmt.Sprintf("%s/%s", c.Name, c.Namespace),
 		TokenEndpointAuthMethod: string(c.Spec.TokenEndpointAuthMethod),
+		Metadata:                c.Spec.Metadata,
 	}
 }
 

--- a/api/v1alpha1/oauth2client_types.go
+++ b/api/v1alpha1/oauth2client_types.go
@@ -108,7 +108,7 @@ type OAuth2ClientSpec struct {
 	TokenEndpointAuthMethod TokenEndpointAuthMethod `json:"tokenEndpointAuthMethod,omitempty"`
 
 	// Metadata is abritrary data
-	Metadata Metadata `json:"metadata,omitempty"`
+	Metadata json.RawMessage `json:"metadata,omitempty"`
 }
 
 // +kubebuilder:validation:Enum=client_credentials;authorization_code;implicit;refresh_token
@@ -126,9 +126,6 @@ type RedirectURI string
 // +kubebuilder:validation:Enum=;client_secret_basic;client_secret_post;private_key_jwt;none
 // TokenEndpointAuthMethod represents an authentication method for token endpoint
 type TokenEndpointAuthMethod string
-
-// Metadata is abritrary data
-type Metadata json.RawMessage
 
 // OAuth2ClientStatus defines the observed state of OAuth2Client
 type OAuth2ClientStatus struct {
@@ -179,7 +176,7 @@ func (c *OAuth2Client) ToOAuth2ClientJSON() *hydra.OAuth2ClientJSON {
 		Scope:                   c.Spec.Scope,
 		Owner:                   fmt.Sprintf("%s/%s", c.Name, c.Namespace),
 		TokenEndpointAuthMethod: string(c.Spec.TokenEndpointAuthMethod),
-		Metadata:                json.RawMessage(c.Spec.Metadata),
+		Metadata:                c.Spec.Metadata,
 	}
 }
 

--- a/api/v1alpha1/oauth2client_types.go
+++ b/api/v1alpha1/oauth2client_types.go
@@ -129,6 +129,7 @@ type RedirectURI string
 // TokenEndpointAuthMethod represents an authentication method for token endpoint
 type TokenEndpointAuthMethod string
 
+// Metadata is abritrary data
 type Metadata map[string]interface{}
 
 // OAuth2ClientStatus defines the observed state of OAuth2Client
@@ -181,6 +182,7 @@ func (c *OAuth2Client) ToOAuth2ClientJSON() *hydra.OAuth2ClientJSON {
 		Scope:                   c.Spec.Scope,
 		Owner:                   fmt.Sprintf("%s/%s", c.Name, c.Namespace),
 		TokenEndpointAuthMethod: string(c.Spec.TokenEndpointAuthMethod),
+		Metadata:                c.Spec.Metadata,
 	}
 }
 

--- a/api/v1alpha1/oauth2client_types.go
+++ b/api/v1alpha1/oauth2client_types.go
@@ -111,7 +111,7 @@ type OAuth2ClientSpec struct {
 	TokenEndpointAuthMethod TokenEndpointAuthMethod `json:"tokenEndpointAuthMethod,omitempty"`
 
 	// Metadata is abritrary data
-	Metadata Metadata `json:"metadata,omitempty"`
+	Metadata json.RawMessage `json:"metadata,omitempty"`
 }
 
 // +kubebuilder:validation:Enum=client_credentials;authorization_code;implicit;refresh_token
@@ -129,9 +129,6 @@ type RedirectURI string
 // +kubebuilder:validation:Enum=;client_secret_basic;client_secret_post;private_key_jwt;none
 // TokenEndpointAuthMethod represents an authentication method for token endpoint
 type TokenEndpointAuthMethod string
-
-// Metadata is abritrary data
-type Metadata json.RawMessage
 
 // OAuth2ClientStatus defines the observed state of OAuth2Client
 type OAuth2ClientStatus struct {
@@ -183,7 +180,7 @@ func (c *OAuth2Client) ToOAuth2ClientJSON() *hydra.OAuth2ClientJSON {
 		Scope:                   c.Spec.Scope,
 		Owner:                   fmt.Sprintf("%s/%s", c.Name, c.Namespace),
 		TokenEndpointAuthMethod: string(c.Spec.TokenEndpointAuthMethod),
-		Metadata:                json.RawMessage(c.Spec.Metadata),
+		Metadata:                c.Spec.Metadata,
 	}
 }
 

--- a/api/v1alpha1/oauth2client_types.go
+++ b/api/v1alpha1/oauth2client_types.go
@@ -183,7 +183,7 @@ func (c *OAuth2Client) ToOAuth2ClientJSON() *hydra.OAuth2ClientJSON {
 		Scope:                   c.Spec.Scope,
 		Owner:                   fmt.Sprintf("%s/%s", c.Name, c.Namespace),
 		TokenEndpointAuthMethod: string(c.Spec.TokenEndpointAuthMethod),
-		Metadata:                c.Spec.Metadata,
+		Metadata:                json.RawMessage(c.Spec.Metadata),
 	}
 }
 

--- a/api/v1alpha1/oauth2client_types.go
+++ b/api/v1alpha1/oauth2client_types.go
@@ -106,8 +106,11 @@ type OAuth2ClientSpec struct {
 
 	// +kubebuilder:validation:Enum=;client_secret_basic;client_secret_post;private_key_jwt;none
 	//
-	// Indication which authenticaiton method shoud be used for the token endpoint
+	// Indication which authentication method shoud be used for the token endpoint
 	TokenEndpointAuthMethod TokenEndpointAuthMethod `json:"tokenEndpointAuthMethod,omitempty"`
+
+	// Metadata is abritrary data
+	Metadata Metadata `json:"metadata,omitempty"`
 }
 
 // +kubebuilder:validation:Enum=client_credentials;authorization_code;implicit;refresh_token
@@ -123,8 +126,10 @@ type ResponseType string
 type RedirectURI string
 
 // +kubebuilder:validation:Enum=;client_secret_basic;client_secret_post;private_key_jwt;none
-// TokenEndpointAuthMethod represents an authenticaiton method for token endpoint
+// TokenEndpointAuthMethod represents an authentication method for token endpoint
 type TokenEndpointAuthMethod string
+
+type Metadata map[string]interface{}
 
 // OAuth2ClientStatus defines the observed state of OAuth2Client
 type OAuth2ClientStatus struct {

--- a/api/v1alpha1/oauth2client_types.go
+++ b/api/v1alpha1/oauth2client_types.go
@@ -179,7 +179,7 @@ func (c *OAuth2Client) ToOAuth2ClientJSON() *hydra.OAuth2ClientJSON {
 		Scope:                   c.Spec.Scope,
 		Owner:                   fmt.Sprintf("%s/%s", c.Name, c.Namespace),
 		TokenEndpointAuthMethod: string(c.Spec.TokenEndpointAuthMethod),
-		Metadata:                c.Spec.Metadata,
+		Metadata:                json.RawMessage(c.Spec.Metadata),
 	}
 }
 

--- a/api/v1alpha1/oauth2client_types.go
+++ b/api/v1alpha1/oauth2client_types.go
@@ -16,6 +16,7 @@ limitations under the License.
 package v1alpha1
 
 import (
+	"encoding/json"
 	"fmt"
 
 	"github.com/ory/hydra-maester/hydra"
@@ -130,7 +131,7 @@ type RedirectURI string
 type TokenEndpointAuthMethod string
 
 // Metadata is abritrary data
-type Metadata map[string]interface{}
+type Metadata json.RawMessage
 
 // OAuth2ClientStatus defines the observed state of OAuth2Client
 type OAuth2ClientStatus struct {

--- a/api/v1alpha1/oauth2client_types.go
+++ b/api/v1alpha1/oauth2client_types.go
@@ -83,6 +83,9 @@ type OAuth2ClientSpec struct {
 	// RedirectURIs is an array of the redirect URIs allowed for the application
 	RedirectURIs []RedirectURI `json:"redirectUris,omitempty"`
 
+	// Audience is a whitelist defining the audiences this client is allowed to request tokens for
+	Audience []string `json:"audience,omitempty"`
+
 	// +kubebuilder:validation:Pattern=([a-zA-Z0-9\.\*]+\s?)+
 	//
 	// Scope is a string containing a space-separated list of scope values (as
@@ -169,6 +172,7 @@ func (c *OAuth2Client) ToOAuth2ClientJSON() *hydra.OAuth2ClientJSON {
 		GrantTypes:              grantToStringSlice(c.Spec.GrantTypes),
 		ResponseTypes:           responseToStringSlice(c.Spec.ResponseTypes),
 		RedirectURIs:            redirectToStringSlice(c.Spec.RedirectURIs),
+		Audience:                c.Spec.Audience,
 		Scope:                   c.Spec.Scope,
 		Owner:                   fmt.Sprintf("%s/%s", c.Name, c.Namespace),
 		TokenEndpointAuthMethod: string(c.Spec.TokenEndpointAuthMethod),

--- a/api/v1alpha1/oauth2client_types.go
+++ b/api/v1alpha1/oauth2client_types.go
@@ -16,6 +16,7 @@ limitations under the License.
 package v1alpha1
 
 import (
+	"encoding/json"
 	"fmt"
 
 	"github.com/ory/hydra-maester/hydra"
@@ -127,7 +128,7 @@ type RedirectURI string
 type TokenEndpointAuthMethod string
 
 // Metadata is abritrary data
-type Metadata map[string]interface{}
+type Metadata json.RawMessage
 
 // OAuth2ClientStatus defines the observed state of OAuth2Client
 type OAuth2ClientStatus struct {

--- a/api/v1alpha1/oauth2client_types.go
+++ b/api/v1alpha1/oauth2client_types.go
@@ -103,8 +103,11 @@ type OAuth2ClientSpec struct {
 
 	// +kubebuilder:validation:Enum=;client_secret_basic;client_secret_post;private_key_jwt;none
 	//
-	// Indication which authenticaiton method shoud be used for the token endpoint
+	// Indication which authentication method shoud be used for the token endpoint
 	TokenEndpointAuthMethod TokenEndpointAuthMethod `json:"tokenEndpointAuthMethod,omitempty"`
+
+	// Metadata is abritrary data
+	Metadata Metadata `json:"metadata,omitempty"`
 }
 
 // +kubebuilder:validation:Enum=client_credentials;authorization_code;implicit;refresh_token
@@ -120,8 +123,10 @@ type ResponseType string
 type RedirectURI string
 
 // +kubebuilder:validation:Enum=;client_secret_basic;client_secret_post;private_key_jwt;none
-// TokenEndpointAuthMethod represents an authenticaiton method for token endpoint
+// TokenEndpointAuthMethod represents an authentication method for token endpoint
 type TokenEndpointAuthMethod string
+
+type Metadata map[string]interface{}
 
 // OAuth2ClientStatus defines the observed state of OAuth2Client
 type OAuth2ClientStatus struct {

--- a/config/crd/bases/hydra.ory.sh_oauth2clients.yaml
+++ b/config/crd/bases/hydra.ory.sh_oauth2clients.yaml
@@ -450,13 +450,16 @@ spec:
               minItems: 1
               type: array
             tokenEndpointAuthMethod:
-              description: Indication which authenticaiton method shoud be used for the token endpoint.
+              description: Indication which authentication method shoud be used for the token endpoint.
               type: string
               enum:
               - client_secret_basic
               - client_secret_post
               - private_key_jwt
               - none
+            metadata:
+              description: Metadata is arbitrary data. This JSON will be stored into client and can be used to hold custom properties
+              type: object
             scope:
               description: Scope is a string containing a space-separated list of
                 scope values (as described in Section 3.3 of OAuth 2.0 [RFC6749])

--- a/config/crd/bases/hydra.ory.sh_oauth2clients.yaml
+++ b/config/crd/bases/hydra.ory.sh_oauth2clients.yaml
@@ -437,6 +437,11 @@ spec:
                 pattern: \w+:/?/?[^\s]+
                 type: string
               type: array
+            audience:
+              description: Audience is a whitelist defining the audiences this client is allowed to request tokens for
+              items:
+                type: string
+              type: array
             responseTypes:
               description: ResponseTypes is an array of the OAuth 2.0 response type
                 strings that the client can use at the authorization endpoint.

--- a/config/crd/bases/hydra.ory.sh_oauth2clients.yaml
+++ b/config/crd/bases/hydra.ory.sh_oauth2clients.yaml
@@ -455,13 +455,16 @@ spec:
               minItems: 1
               type: array
             tokenEndpointAuthMethod:
-              description: Indication which authenticaiton method shoud be used for the token endpoint.
+              description: Indication which authentication method shoud be used for the token endpoint.
               type: string
               enum:
               - client_secret_basic
               - client_secret_post
               - private_key_jwt
               - none
+            metadata:
+              description: Metadata is arbitrary data. This JSON will be stored into client and can be used to hold custom properties
+              type: object
             scope:
               description: Scope is a string containing a space-separated list of
                 scope values (as described in Section 3.3 of OAuth 2.0 [RFC6749])

--- a/config/samples/hydra_v1alpha1_oauth2client.yaml
+++ b/config/samples/hydra_v1alpha1_oauth2client.yaml
@@ -30,4 +30,7 @@ spec:
     endpoint: /clients
     forwardedProto: https
   tokenEndpointAuthMethod: client_secret_basic
+  metadata:
+    property1: 1
+    propetry2: "2"
   

--- a/config/samples/hydra_v1alpha1_oauth2client.yaml
+++ b/config/samples/hydra_v1alpha1_oauth2client.yaml
@@ -19,6 +19,9 @@ spec:
   redirectUris:
     - https://client/account
     - http://localhost:8080
+  audience:
+    - audience-a
+    - audience-b
   hydraAdmin:
     # if hydraAdmin is specified, all of these fields are requried,
     # but they can be empty/0

--- a/config/samples/hydra_v1alpha1_oauth2client.yaml
+++ b/config/samples/hydra_v1alpha1_oauth2client.yaml
@@ -27,4 +27,7 @@ spec:
     endpoint: /clients
     forwardedProto: https
   tokenEndpointAuthMethod: client_secret_basic
+  metadata:
+    property1: 1
+    propetry2: "2"
   

--- a/config/samples/hydra_v1alpha1_oauth2client.yaml
+++ b/config/samples/hydra_v1alpha1_oauth2client.yaml
@@ -32,5 +32,5 @@ spec:
   tokenEndpointAuthMethod: client_secret_basic
   metadata:
     property1: 1
-    propetry2: "2"
+    property2: "2"
   

--- a/config/samples/hydra_v1alpha1_oauth2client.yaml
+++ b/config/samples/hydra_v1alpha1_oauth2client.yaml
@@ -29,5 +29,5 @@ spec:
   tokenEndpointAuthMethod: client_secret_basic
   metadata:
     property1: 1
-    propetry2: "2"
+    property2: "2"
   

--- a/config/samples/hydra_v1alpha1_oauth2client_user_credentials.yaml
+++ b/config/samples/hydra_v1alpha1_oauth2client_user_credentials.yaml
@@ -8,7 +8,7 @@ data:
   client_id: MDA5MDA5MDA=
   client_secret: czNjUjM3cDRzc1ZWMHJEMTIzNA==
 ---
-apiVersion: hydra.ory.sh/v1alpha2
+apiVersion: hydra.ory.sh/v1alpha1
 kind: OAuth2Client
 metadata:
   name: my-oauth2-client-2

--- a/config/samples/hydra_v1alpha1_oauth2client_user_credentials.yaml
+++ b/config/samples/hydra_v1alpha1_oauth2client_user_credentials.yaml
@@ -29,6 +29,9 @@ spec:
   redirectUris:
     - https://client/account
     - http://localhost:8080
+  audience:
+    - audience-a
+    - audience-b
   hydraAdmin:
     # if hydraAdmin is specified, all of these fields are requried,
     # but they can be empty/0

--- a/config/samples/hydra_v1alpha1_oauth2client_user_credentials.yaml
+++ b/config/samples/hydra_v1alpha1_oauth2client_user_credentials.yaml
@@ -37,3 +37,6 @@ spec:
     endpoint: /clients
     forwardedProto: https
   tokenEndpointAuthMethod: client_secret_basic
+  metadata:
+    property1: 1
+    propetry2: "2"

--- a/config/samples/hydra_v1alpha1_oauth2client_user_credentials.yaml
+++ b/config/samples/hydra_v1alpha1_oauth2client_user_credentials.yaml
@@ -42,4 +42,4 @@ spec:
   tokenEndpointAuthMethod: client_secret_basic
   metadata:
     property1: 1
-    propetry2: "2"
+    property2: "2"

--- a/config/samples/hydra_v1alpha1_oauth2client_user_credentials.yaml
+++ b/config/samples/hydra_v1alpha1_oauth2client_user_credentials.yaml
@@ -40,3 +40,6 @@ spec:
     endpoint: /clients
     forwardedProto: https
   tokenEndpointAuthMethod: client_secret_basic
+  metadata:
+    property1: 1
+    propetry2: "2"

--- a/config/samples/hydra_v1alpha1_oauth2client_user_credentials.yaml
+++ b/config/samples/hydra_v1alpha1_oauth2client_user_credentials.yaml
@@ -39,4 +39,4 @@ spec:
   tokenEndpointAuthMethod: client_secret_basic
   metadata:
     property1: 1
-    propetry2: "2"
+    property2: "2"

--- a/controllers/oauth2client_controller_integration_test.go
+++ b/controllers/oauth2client_controller_integration_test.go
@@ -70,6 +70,7 @@ var _ = Describe("OAuth2Client Controller", func() {
 						ResponseTypes: o.ResponseTypes,
 						RedirectURIs:  o.RedirectURIs,
 						Scope:         o.Scope,
+						Audience:      o.Audience,
 						Owner:         o.Owner,
 					}
 				}, func(o *hydra.OAuth2ClientJSON) error {
@@ -214,6 +215,7 @@ var _ = Describe("OAuth2Client Controller", func() {
 						GrantTypes:    o.GrantTypes,
 						ResponseTypes: o.ResponseTypes,
 						RedirectURIs:  o.RedirectURIs,
+						Audience:      o.Audience,
 						Scope:         o.Scope,
 						Owner:         o.Owner,
 					}
@@ -402,6 +404,7 @@ func testInstance(name, secretName string) *hydrav1alpha1.OAuth2Client {
 			ResponseTypes: []hydrav1alpha1.ResponseType{"token"},
 			Scope:         "a b c",
 			RedirectURIs:  []hydrav1alpha1.RedirectURI{"https://example.com"},
+			Audience:      []string{"audience-a"},
 			SecretName:    secretName,
 			HydraAdmin: hydrav1alpha1.HydraAdmin{
 				URL:            "http://hydra-admin",

--- a/hydra/client_test.go
+++ b/hydra/client_test.go
@@ -23,8 +23,8 @@ const (
 
 	testID            = "test-id"
 	testClient        = `{"client_id":"test-id","owner":"test-name","scope":"some,scopes","grant_types":["type1"],"token_endpoint_auth_method":"client_secret_basic"}`
-	testClientCreated = `{"client_id":"test-id-2","client_secret":"TmGkvcY7k526","owner":"test-name-2","scope":"some,other,scopes","grant_types":["type2"],"token_endpoint_auth_method":"client_secret_basic"}`
-	testClientUpdated = `{"client_id":"test-id-3","client_secret":"xFoPPm654por","owner":"test-name-3","scope":"yet,another,scope","grant_types":["type3"],"token_endpoint_auth_method":"client_secret_basic"}`
+	testClientCreated = `{"client_id":"test-id-2","client_secret":"TmGkvcY7k526","owner":"test-name-2","scope":"some,other,scopes","grant_types":["type2"],"audience":["audience-a","audience-b"],"token_endpoint_auth_method":"client_secret_basic"}`
+	testClientUpdated = `{"client_id":"test-id-3","client_secret":"xFoPPm654por","owner":"test-name-3","scope":"yet,another,scope","grant_types":["type3"],"audience":["audience-c"],"token_endpoint_auth_method":"client_secret_basic"}`
 	testClientList    = `{"client_id":"test-id-4","owner":"test-name-4","scope":"scope1 scope2","grant_types":["type4"],"token_endpoint_auth_method":"client_secret_basic"}`
 	testClientList2   = `{"client_id":"test-id-5","owner":"test-name-5","scope":"scope3 scope4","grant_types":["type5"],"token_endpoint_auth_method":"client_secret_basic"}`
 
@@ -43,6 +43,7 @@ var testOAuthJSONPost = &hydra.OAuth2ClientJSON{
 	Scope:      "some,other,scopes",
 	GrantTypes: []string{"type2"},
 	Owner:      "test-name-2",
+	Audience:   []string{"audience-a", "audience-b"},
 }
 
 var testOAuthJSONPut = &hydra.OAuth2ClientJSON{
@@ -50,6 +51,7 @@ var testOAuthJSONPut = &hydra.OAuth2ClientJSON{
 	Scope:      "yet,another,scope",
 	GrantTypes: []string{"type3"},
 	Owner:      "test-name-3",
+	Audience:   []string{"audience-c"},
 }
 
 func TestCRUD(t *testing.T) {
@@ -170,6 +172,7 @@ func TestCRUD(t *testing.T) {
 					assert.Equal(testOAuthJSONPost.Scope, o.Scope)
 					assert.Equal(testOAuthJSONPost.GrantTypes, o.GrantTypes)
 					assert.Equal(testOAuthJSONPost.Owner, o.Owner)
+					assert.Equal(testOAuthJSONPost.Audience, o.Audience)
 					assert.NotNil(o.Secret)
 					assert.NotNil(o.ClientID)
 					assert.NotNil(o.TokenEndpointAuthMethod)
@@ -228,6 +231,7 @@ func TestCRUD(t *testing.T) {
 					assert.Equal(testOAuthJSONPut.GrantTypes, o.GrantTypes)
 					assert.Equal(testOAuthJSONPut.ClientID, o.ClientID)
 					assert.Equal(testOAuthJSONPut.Owner, o.Owner)
+					assert.Equal(testOAuthJSONPut.Audience, o.Audience)
 					assert.NotNil(o.Secret)
 				}
 			})

--- a/hydra/client_test.go
+++ b/hydra/client_test.go
@@ -47,16 +47,6 @@ var testOAuthJSONPost = &hydra.OAuth2ClientJSON{
 	Audience:   []string{"audience-a", "audience-b"},
 }
 
-var testOAuthJSONPost2 = &hydra.OAuth2ClientJSON{
-	Scope:      "some,other,scopes",
-	GrantTypes: []string{"type2"},
-	Owner:      "test-name-21",
-	Metadata: map[string]interface{}{
-		"property1": float64(1),
-		"property2": "2",
-	},
-}
-
 var testOAuthJSONPut = &hydra.OAuth2ClientJSON{
 	ClientID:   pointer.StringPtr("test-id-3"),
 	Scope:      "yet,another,scope",
@@ -178,6 +168,16 @@ func TestCRUD(t *testing.T) {
 
 				//when
 				if newWithMetadata {
+					meta, _ := json.Marshal(map[string]interface{}{
+						"property1": float64(1),
+						"property2": "2",
+					})
+					var testOAuthJSONPost2 = &hydra.OAuth2ClientJSON{
+						Scope:      "some,other,scopes",
+						GrantTypes: []string{"type2"},
+						Owner:      "test-name-21",
+						Metadata:   meta,
+					}
 					o, err = c.PostOAuth2Client(testOAuthJSONPost2)
 					expected = testOAuthJSONPost2
 				} else {

--- a/hydra/client_test.go
+++ b/hydra/client_test.go
@@ -46,16 +46,6 @@ var testOAuthJSONPost = &hydra.OAuth2ClientJSON{
 	Owner:      "test-name-2",
 }
 
-var testOAuthJSONPost2 = &hydra.OAuth2ClientJSON{
-	Scope:      "some,other,scopes",
-	GrantTypes: []string{"type2"},
-	Owner:      "test-name-21",
-	Metadata: map[string]interface{}{
-		"property1": float64(1),
-		"property2": "2",
-	},
-}
-
 var testOAuthJSONPut = &hydra.OAuth2ClientJSON{
 	ClientID:   pointer.StringPtr("test-id-3"),
 	Scope:      "yet,another,scope",
@@ -176,6 +166,16 @@ func TestCRUD(t *testing.T) {
 
 				//when
 				if newWithMetadata {
+					meta, _ := json.Marshal(map[string]interface{}{
+						"property1": float64(1),
+						"property2": "2",
+					})
+					var testOAuthJSONPost2 = &hydra.OAuth2ClientJSON{
+						Scope:      "some,other,scopes",
+						GrantTypes: []string{"type2"},
+						Owner:      "test-name-21",
+						Metadata:   meta,
+					}
 					o, err = c.PostOAuth2Client(testOAuthJSONPost2)
 					expected = testOAuthJSONPost2
 				} else {

--- a/hydra/client_test.go
+++ b/hydra/client_test.go
@@ -21,12 +21,13 @@ const (
 	clientsEndpoint = "/clients"
 	schemeHTTP      = "http"
 
-	testID            = "test-id"
-	testClient        = `{"client_id":"test-id","owner":"test-name","scope":"some,scopes","grant_types":["type1"],"token_endpoint_auth_method":"client_secret_basic"}`
-	testClientCreated = `{"client_id":"test-id-2","client_secret":"TmGkvcY7k526","owner":"test-name-2","scope":"some,other,scopes","grant_types":["type2"],"token_endpoint_auth_method":"client_secret_basic"}`
-	testClientUpdated = `{"client_id":"test-id-3","client_secret":"xFoPPm654por","owner":"test-name-3","scope":"yet,another,scope","grant_types":["type3"],"token_endpoint_auth_method":"client_secret_basic"}`
-	testClientList    = `{"client_id":"test-id-4","owner":"test-name-4","scope":"scope1 scope2","grant_types":["type4"],"token_endpoint_auth_method":"client_secret_basic"}`
-	testClientList2   = `{"client_id":"test-id-5","owner":"test-name-5","scope":"scope3 scope4","grant_types":["type5"],"token_endpoint_auth_method":"client_secret_basic"}`
+	testID                        = "test-id"
+	testClient                    = `{"client_id":"test-id","owner":"test-name","scope":"some,scopes","grant_types":["type1"],"token_endpoint_auth_method":"client_secret_basic"}`
+	testClientCreated             = `{"client_id":"test-id-2","client_secret":"TmGkvcY7k526","owner":"test-name-2","scope":"some,other,scopes","grant_types":["type2"],"token_endpoint_auth_method":"client_secret_basic"}`
+	testClientWithMetadataCreated = `{"client_id":"test-id-21","client_secret":"TmGkvcY7k526","owner":"test-name-21","scope":"some,other,scopes","grant_types":["type2"],"token_endpoint_auth_method":"client_secret_basic","metadata":{"property1":1,"property2":"2"}}`
+	testClientUpdated             = `{"client_id":"test-id-3","client_secret":"xFoPPm654por","owner":"test-name-3","scope":"yet,another,scope","grant_types":["type3"],"token_endpoint_auth_method":"client_secret_basic"}`
+	testClientList                = `{"client_id":"test-id-4","owner":"test-name-4","scope":"scope1 scope2","grant_types":["type4"],"token_endpoint_auth_method":"client_secret_basic"}`
+	testClientList2               = `{"client_id":"test-id-5","owner":"test-name-5","scope":"scope3 scope4","grant_types":["type5"],"token_endpoint_auth_method":"client_secret_basic"}`
 
 	statusNotFoundBody            = `{"error":"Not Found","error_description":"Unable to locate the requested resource","status_code":404,"request_id":"id"}`
 	statusConflictBody            = `{"error":"Unable to insert or update resource because a resource with that value exists already","error_description":"","status_code":409,"request_id":"id"`
@@ -43,6 +44,16 @@ var testOAuthJSONPost = &hydra.OAuth2ClientJSON{
 	Scope:      "some,other,scopes",
 	GrantTypes: []string{"type2"},
 	Owner:      "test-name-2",
+}
+
+var testOAuthJSONPost2 = &hydra.OAuth2ClientJSON{
+	Scope:      "some,other,scopes",
+	GrantTypes: []string{"type2"},
+	Owner:      "test-name-21",
+	Metadata: map[string]interface{}{
+		"property1": float64(1),
+		"property2": "2",
+	},
 }
 
 var testOAuthJSONPut = &hydra.OAuth2ClientJSON{
@@ -126,6 +137,11 @@ func TestCRUD(t *testing.T) {
 				testClientCreated,
 				nil,
 			},
+			"with new client with metadata": {
+				http.StatusCreated,
+				testClientWithMetadataCreated,
+				nil,
+			},
 			"with existing client": {
 				http.StatusConflict,
 				statusConflictBody,
@@ -138,9 +154,14 @@ func TestCRUD(t *testing.T) {
 			},
 		} {
 			t.Run(fmt.Sprintf("case/%s", d), func(t *testing.T) {
-
+				var (
+					err      error
+					o        *hydra.OAuth2ClientJSON
+					expected *hydra.OAuth2ClientJSON
+				)
 				//given
 				new := tc.statusCode == http.StatusCreated
+				newWithMetadata := d == "with new client with metadata"
 
 				h := http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
 					assert.Equal(c.HydraURL.String(), fmt.Sprintf("%s://%s%s", schemeHTTP, req.Host, req.URL.Path))
@@ -154,7 +175,13 @@ func TestCRUD(t *testing.T) {
 				runServer(&c, h)
 
 				//when
-				o, err := c.PostOAuth2Client(testOAuthJSONPost)
+				if newWithMetadata {
+					o, err = c.PostOAuth2Client(testOAuthJSONPost2)
+					expected = testOAuthJSONPost2
+				} else {
+					o, err = c.PostOAuth2Client(testOAuthJSONPost)
+					expected = testOAuthJSONPost
+				}
 
 				//then
 				if tc.err == nil {
@@ -166,15 +193,23 @@ func TestCRUD(t *testing.T) {
 
 				if new {
 					require.NotNil(t, o)
-
-					assert.Equal(testOAuthJSONPost.Scope, o.Scope)
-					assert.Equal(testOAuthJSONPost.GrantTypes, o.GrantTypes)
-					assert.Equal(testOAuthJSONPost.Owner, o.Owner)
+					assert.Equal(expected.Scope, o.Scope)
+					assert.Equal(expected.GrantTypes, o.GrantTypes)
+					assert.Equal(expected.Owner, o.Owner)
 					assert.NotNil(o.Secret)
 					assert.NotNil(o.ClientID)
 					assert.NotNil(o.TokenEndpointAuthMethod)
-					if testOAuthJSONPost.TokenEndpointAuthMethod != "" {
-						assert.Equal(testOAuthJSONPost.TokenEndpointAuthMethod, o.TokenEndpointAuthMethod)
+					if expected.TokenEndpointAuthMethod != "" {
+						assert.Equal(expected.TokenEndpointAuthMethod, o.TokenEndpointAuthMethod)
+					}
+					if newWithMetadata {
+						assert.NotNil(o.Metadata)
+						assert.True(len(o.Metadata) > 0)
+						for key, _ := range o.Metadata {
+							assert.Equal(o.Metadata[key], expected.Metadata[key])
+						}
+					} else {
+						assert.Nil(o.Metadata)
 					}
 				}
 			})

--- a/hydra/types.go
+++ b/hydra/types.go
@@ -9,6 +9,7 @@ type OAuth2ClientJSON struct {
 	GrantTypes              []string `json:"grant_types"`
 	RedirectURIs            []string `json:"redirect_uris,omitempty"`
 	ResponseTypes           []string `json:"response_types,omitempty"`
+	Audience                []string `json:"audience,omitempty"`
 	Scope                   string   `json:"scope"`
 	Owner                   string   `json:"owner"`
 	TokenEndpointAuthMethod string   `json:"token_endpoint_auth_method,omitempty"`

--- a/hydra/types.go
+++ b/hydra/types.go
@@ -1,18 +1,21 @@
 package hydra
 
-import "k8s.io/utils/pointer"
+import (
+	"k8s.io/utils/pointer"
+)
 
 // OAuth2ClientJSON represents an OAuth2 client digestible by ORY Hydra
 type OAuth2ClientJSON struct {
-	ClientID                *string  `json:"client_id,omitempty"`
-	Secret                  *string  `json:"client_secret,omitempty"`
-	GrantTypes              []string `json:"grant_types"`
-	RedirectURIs            []string `json:"redirect_uris,omitempty"`
-	ResponseTypes           []string `json:"response_types,omitempty"`
-	Audience                []string `json:"audience,omitempty"`
-	Scope                   string   `json:"scope"`
-	Owner                   string   `json:"owner"`
-	TokenEndpointAuthMethod string   `json:"token_endpoint_auth_method,omitempty"`
+	ClientID                *string                `json:"client_id,omitempty"`
+	Secret                  *string                `json:"client_secret,omitempty"`
+	GrantTypes              []string               `json:"grant_types"`
+	RedirectURIs            []string               `json:"redirect_uris,omitempty"`
+	ResponseTypes           []string               `json:"response_types,omitempty"`
+	Audience                []string               `json:"audience,omitempty"`
+	Scope                   string                 `json:"scope"`
+	Owner                   string                 `json:"owner"`
+	TokenEndpointAuthMethod string                 `json:"token_endpoint_auth_method,omitempty"`
+	Metadata                map[string]interface{} `json:"metadata,omitempty"`
 }
 
 // Oauth2ClientCredentials represents client ID and password fetched from a Kubernetes secret

--- a/hydra/types.go
+++ b/hydra/types.go
@@ -1,20 +1,22 @@
 package hydra
 
 import (
+	"encoding/json"
+
 	"k8s.io/utils/pointer"
 )
 
 // OAuth2ClientJSON represents an OAuth2 client digestible by ORY Hydra
 type OAuth2ClientJSON struct {
-	ClientID                *string                `json:"client_id,omitempty"`
-	Secret                  *string                `json:"client_secret,omitempty"`
-	GrantTypes              []string               `json:"grant_types"`
-	RedirectURIs            []string               `json:"redirect_uris,omitempty"`
-	ResponseTypes           []string               `json:"response_types,omitempty"`
-	Scope                   string                 `json:"scope"`
-	Owner                   string                 `json:"owner"`
-	TokenEndpointAuthMethod string                 `json:"token_endpoint_auth_method,omitempty"`
-	Metadata                map[string]interface{} `json:"metadata,omitempty"`
+	ClientID                *string         `json:"client_id,omitempty"`
+	Secret                  *string         `json:"client_secret,omitempty"`
+	GrantTypes              []string        `json:"grant_types"`
+	RedirectURIs            []string        `json:"redirect_uris,omitempty"`
+	ResponseTypes           []string        `json:"response_types,omitempty"`
+	Scope                   string          `json:"scope"`
+	Owner                   string          `json:"owner"`
+	TokenEndpointAuthMethod string          `json:"token_endpoint_auth_method,omitempty"`
+	Metadata                json.RawMessage `json:"metadata,omitempty"`
 }
 
 // Oauth2ClientCredentials represents client ID and password fetched from a Kubernetes secret

--- a/hydra/types.go
+++ b/hydra/types.go
@@ -1,17 +1,20 @@
 package hydra
 
-import "k8s.io/utils/pointer"
+import (
+	"k8s.io/utils/pointer"
+)
 
 // OAuth2ClientJSON represents an OAuth2 client digestible by ORY Hydra
 type OAuth2ClientJSON struct {
-	ClientID                *string  `json:"client_id,omitempty"`
-	Secret                  *string  `json:"client_secret,omitempty"`
-	GrantTypes              []string `json:"grant_types"`
-	RedirectURIs            []string `json:"redirect_uris,omitempty"`
-	ResponseTypes           []string `json:"response_types,omitempty"`
-	Scope                   string   `json:"scope"`
-	Owner                   string   `json:"owner"`
-	TokenEndpointAuthMethod string   `json:"token_endpoint_auth_method,omitempty"`
+	ClientID                *string                `json:"client_id,omitempty"`
+	Secret                  *string                `json:"client_secret,omitempty"`
+	GrantTypes              []string               `json:"grant_types"`
+	RedirectURIs            []string               `json:"redirect_uris,omitempty"`
+	ResponseTypes           []string               `json:"response_types,omitempty"`
+	Scope                   string                 `json:"scope"`
+	Owner                   string                 `json:"owner"`
+	TokenEndpointAuthMethod string                 `json:"token_endpoint_auth_method,omitempty"`
+	Metadata                map[string]interface{} `json:"metadata,omitempty"`
 }
 
 // Oauth2ClientCredentials represents client ID and password fetched from a Kubernetes secret


### PR DESCRIPTION
- added Metadata map[string]interface{} into OAuth2ClientSpec
- added explicit test on POST route to check for metadata and omitted metadata