### PR TITLE
Fix sample apiVersion

### DIFF
--- a/config/samples/hydra_v1alpha1_oauth2client_user_credentials.yaml
+++ b/config/samples/hydra_v1alpha1_oauth2client_user_credentials.yaml
@@ -8,7 +8,7 @@ data:
   client_id: MDA5MDA5MDA=
   client_secret: czNjUjM3cDRzc1ZWMHJEMTIzNA==
 ---
-apiVersion: hydra.ory.sh/v1alpha2
+apiVersion: hydra.ory.sh/v1alpha1
 kind: OAuth2Client
 metadata:
   name: my-oauth2-client-2


### PR DESCRIPTION
The hydra.ory.sh/v1alpha2 was never released. Let's keep the
sample at the proper apiVersion.