### PR TITLE
feat: Adding oauth client name to the CRD spec

### DIFF
--- a/api/v1alpha1/oauth2client_types.go
+++ b/api/v1alpha1/oauth2client_types.go
@@ -68,6 +68,10 @@ type HydraAdmin struct {
 
 // OAuth2ClientSpec defines the desired state of OAuth2Client
 type OAuth2ClientSpec struct {
+
+	// ClientName is the human-readable string name of the client to be presented to the end-user during authorization.
+	ClientName string `json:"clientName,omitempty"`
+
 	// +kubebuilder:validation:MaxItems=4
 	// +kubebuilder:validation:MinItems=1
 	//
@@ -176,6 +180,7 @@ func init() {
 // ToOAuth2ClientJSON converts an OAuth2Client into a OAuth2ClientJSON object that represents an OAuth2 client digestible by ORY Hydra
 func (c *OAuth2Client) ToOAuth2ClientJSON() *hydra.OAuth2ClientJSON {
 	return &hydra.OAuth2ClientJSON{
+		ClientName:              c.Spec.ClientName,
 		GrantTypes:              grantToStringSlice(c.Spec.GrantTypes),
 		ResponseTypes:           responseToStringSlice(c.Spec.ResponseTypes),
 		RedirectURIs:            redirectToStringSlice(c.Spec.RedirectURIs),

--- a/config/crd/bases/hydra.ory.sh_oauth2clients.yaml
+++ b/config/crd/bases/hydra.ory.sh_oauth2clients.yaml
@@ -393,6 +393,10 @@ spec:
               items:
                 type: string
               type: array
+            clientName:
+              description: ClientName is the human-readable string name of the client
+                to be presented to the end-user during authorization.
+              type: string
             grantTypes:
               description: GrantTypes is an array of grant types the client is allowed
                 to use.

--- a/hydra/types.go
+++ b/hydra/types.go
@@ -8,6 +8,7 @@ import (
 
 // OAuth2ClientJSON represents an OAuth2 client digestible by ORY Hydra
 type OAuth2ClientJSON struct {
+	ClientName              string          `json:"client_name,omitempty"`
 	ClientID                *string         `json:"client_id,omitempty"`
 	Secret                  *string         `json:"client_secret,omitempty"`
 	GrantTypes              []string        `json:"grant_types"`


### PR DESCRIPTION
Hi guys! 

As part of #36 
With these changes, we are now able to set the client's name through the OAuth2Client CRD.
