### PR TITLE
chore: update repository template to 0f4b64a2

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,6 +1,6 @@
 blank_issues_enabled: false
 contact_links:
-  - name: Ory Ory Oathkeeper Maester Forum
+  - name: Ory Ory Hydra Maester Forum
     url: https://github.com/ory/hydra-maester/discussions
     about: Please ask and answer questions here, show your implementations and discuss ideas.
   - name: Ory Chat
@@ -8,4 +8,4 @@ contact_links:
     about: Hang out with other Ory community members and ask and answer questions.
   - name: Ory Support for Business
     url: https://github.com/ory/open-source-support/blob/master/README.md
-    about: Buy professional support for Ory Ory Oathkeeper Maester.
+    about: Buy professional support for Ory Ory Hydra Maester.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,4 +1,16 @@
-## Related issue
+<!--
+Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
+
+This text will be included in the changelog. If applicable, include links to documentation or pieces of code.
+If your change includes breaking changes please add a codeblock documenting the breaking change:
+
+```
+BREAKING CHANGES: This patch changes the behavior of configuration item `foo` to do bar. To keep the existing
+behavior please do baz.
+```
+-->
+
+## Related issue(s)
 
 <!--
 Please link the GitHub issue this pull request resolves in the format of `#1234`. If you discussed this change
@@ -9,12 +21,6 @@ chance substantial changes will be requested or that the changes will be rejecte
 
 You can discuss changes with maintainers either in the Github Discusssions in this repository or
 join the [Ory Chat](https://www.ory.sh/chat).
--->
-
-## Proposed changes
-
-<!--
-Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
 -->
 
 ## Checklist

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,7 +8,7 @@ https://github.com/ory/meta/blob/master/templates/repository/common/CONTRIBUTING
 
 -->
 
-# Contributing to Ory Ory Oathkeeper Maester
+# Contributing to Ory Ory Hydra Maester
 
 <!-- START doctoc generated TOC please keep comment here to allow auto update -->
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
@@ -21,7 +21,6 @@ https://github.com/ory/meta/blob/master/templates/repository/common/CONTRIBUTING
 - [Documentation](#documentation)
 - [Disclosing vulnerabilities](#disclosing-vulnerabilities)
 - [Code Style](#code-style)
-- [Pull request procedure](#pull-request-procedure)
   - [Working with Forks](#working-with-forks)
 - [Conduct](#conduct)
 
@@ -33,8 +32,8 @@ There are many ways in which you can contribute, beyond writing code. The goal
 of this document is to provide a high-level overview of how you can get
 involved.
 
-_Please note_: We take Ory Ory Oathkeeper Maester's security and our users' trust very
-seriously. If you believe you have found a security issue in Ory Ory Oathkeeper Maester,
+_Please note_: We take Ory Ory Hydra Maester's security and our users' trust very
+seriously. If you believe you have found a security issue in Ory Ory Hydra Maester,
 please responsibly disclose by contacting us at security@ory.sh.
 
 First: As a potential contributor, your changes and ideas are welcome at any
@@ -49,9 +48,9 @@ contributions, and don't want a wall of rules to get in the way of that.
 That said, if you want to ensure that a pull request is likely to be merged,
 talk to us! You can find out our thoughts and ensure that your contribution
 won't clash or be obviated by Ory
-Ory Oathkeeper Maester's normal direction. A great way to
+Ory Hydra Maester's normal direction. A great way to
 do this is via
-[Ory Ory Oathkeeper Maester Discussions](https://github.com/ory/meta/discussions)
+[Ory Ory Hydra Maester Discussions](https://github.com/ory/meta/discussions)
 or the [Ory Chat](https://www.ory.sh/chat).
 
 ## FAQ
@@ -60,21 +59,21 @@ or the [Ory Chat](https://www.ory.sh/chat).
   [Ory Community Code of Conduct?](https://github.com/ory/hydra-maester/blob/master/CODE_OF_CONDUCT.md)
 
 - I have a question. Where can I get
-  [answers to questions regarding Ory Ory Oathkeeper Maester?](#communication)
+  [answers to questions regarding Ory Ory Hydra Maester?](#communication)
 
 - I would like to contribute but I am not sure how. Are there
   [easy ways to contribute?](#how-can-i-contribute)
   [Or good first issues?](https://github.com/search?l=&o=desc&q=label%3A%22help+wanted%22+label%3A%22good+first+issue%22+is%3Aopen+user%3Aory+user%3Aory-corp&s=updated&type=Issues)
 
-- I want to talk to other Ory Ory Oathkeeper Maester users.
+- I want to talk to other Ory Ory Hydra Maester users.
   [How can I become a part of the community?](#communication)
 
 - I would like to know what I am agreeing to when I contribute to Ory
-  Ory Oathkeeper Maester.
+  Ory Hydra Maester.
   Does Ory have
   [a Contributors License Agreement?](https://cla-assistant.io/ory/hydra-maester)
 
-- I would like updates about new versions of Ory Ory Oathkeeper Maester.
+- I would like updates about new versions of Ory Ory Hydra Maester.
   [How are new releases announced?](https://ory.us10.list-manage.com/subscribe?u=ffb1a878e4ec6c0ed312a3480&id=f605a41b53)
 
 ## How can I contribute?
@@ -86,7 +85,7 @@ There are many other ways you can contribute without writing any code. Here are
 a few things you can do to help out:
 
 - **Give us a star.** It may not seem like much, but it really makes a
-  difference. This is something that everyone can do to help out Ory Ory Oathkeeper Maester.
+  difference. This is something that everyone can do to help out Ory Ory Hydra Maester.
   Github stars help the project gain visibility and stand out.
 
 - **Join the community.** Sometimes helping people can be as easy as listening
@@ -94,7 +93,7 @@ a few things you can do to help out:
   look at discussions in the forum and take part in our weekly hangout. More
   info on this in [Communication](#communication).
 
-- **Helping with open issues.** We have a lot of open issues for Ory Ory Oathkeeper Maester
+- **Helping with open issues.** We have a lot of open issues for Ory Ory Hydra Maester
   and some of them may lack necessary information, some are duplicates of older
   issues. You can help out by guiding people through the process of filling out
   the issue template, asking for clarifying information, or pointing them to
@@ -113,14 +112,14 @@ a few things you can do to help out:
 We use [Slack](https://www.ory.sh/chat). You are welcome to drop in and ask
 questions, discuss bugs and feature requests, talk to other users of Ory, etc.
 
-Check out [Ory Ory Oathkeeper Maester Discussions](https://github.com/ory/meta/discussions). This is a great place for
+Check out [Ory Ory Hydra Maester Discussions](https://github.com/ory/meta/discussions). This is a great place for
 in-depth discussions and lots of code examples, logs and similar data.
 
 You can also join our community hangout, if you want to speak to the Ory team
 directly or ask some questions. You can find more info on the hangouts in
 [Slack](https://www.ory.sh/chat).
 
-If you want to receive regular notifications about updates to Ory Ory Oathkeeper Maester,
+If you want to receive regular notifications about updates to Ory Ory Hydra Maester,
 consider joining the mailing list. We will _only_ send you vital information on
 the projects that you are interested in.
 
@@ -130,21 +129,37 @@ Also [follow us on twitter](https://twitter.com/orycorp).
 
 Unless you are fixing a known bug, we **strongly** recommend discussing it with
 the core team via a GitHub issue or [in our chat](https://www.ory.sh/chat)
-before getting started to ensure your work is consistent with Ory Ory Oathkeeper Maester's
+before getting started to ensure your work is consistent with Ory Ory Hydra Maester's
 roadmap and architecture.
 
-All contributions are made via pull request. Note that **all patches from all
-contributors get reviewed**. After a pull request is made other contributors
-will offer feedback, and if the patch passes review a maintainer will accept it
-with a comment. When pull requests fail testing, authors are expected to update
-their pull requests to address the failures until the tests pass and the pull
-request merges successfully. Look here for more info on the
-[Pull request procedure](#pull-request-procedure).
+All contributions are made via pull requests. To make a pull request, you will
+need a GitHub account; if you are unclear on this process, see GitHub's
+documentation on [forking](https://help.github.com/articles/fork-a-repo) and
+[pull requests](https://help.github.com/articles/using-pull-requests). Pull
+requests should be targeted at the `master` branch. Before creating a pull
+request, go through this checklist:
 
-At least one review from a maintainer is required for all patches (even patches
-from maintainers).
+1. Create a feature branch off of `master` so that changes do not get mixed up.
+1. [Rebase](http://git-scm.com/book/en/Git-Branching-Rebasing) your local
+   changes against the `master` branch.
+1. Run the full project test suite with the `go test -tags sqlite ./...` (or
+   equivalent) command and confirm that it passes.
+1. Run `make format` if a `Makefile` is available, `gofmt -s` if the project is
+   written in Go, `npm run format` if the project is written for NodeJS.
+1. Ensure that each commit has a descriptive prefix. This ensures a uniform
+   commit history and helps structure the changelog.  
+   Please refer to this
+   [list of prefixes for Ory Hydra Maester](https://github.com/ory/hydra-maester/blob/master/.github/semantic.yml)
+   for an overview.
+1. Sign-up with CircleCI so that it has access to your repository with the
+   branch containing your PR. Simply creating a CircleCI account is sufficient
+   for the CI jobs to run, you do not need to setup a CircleCI project for the
+   branch.
 
-Before your contributions can be merged you need to sign our
+If a pull request is not ready to be reviewed yet
+[it should be marked as a "Draft"](https://docs.github.com/en/github/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/changing-the-stage-of-a-pull-request).
+
+Before your contributions can be reviewed you need to sign our
 [Contributor License Agreement](https://cla-assistant.io/ory/hydra-maester).
 
 This agreement defines the terms under which your code is contributed to Ory.
@@ -153,9 +168,26 @@ us the rights to use your contribution. You can see the Apache 2.0 license under
 which our projects are published
 [here](https://github.com/ory/meta/blob/master/LICENSE).
 
-Reviewers should leave a "LGTM" comment once they are satisfied with the patch.
-If the patch was submitted by a maintainer with write access, the pull request
-should be merged by the submitter after review.
+When pull requests fail testing, authors are expected to update their pull
+requests to address the failures until the tests pass.
+
+Pull requests eligible for review
+
+1. follow the repository's code formatting conventions;
+2. include tests which prove that the change works as intended and does not add
+   regressions;
+3. document the changes in the code and/or the project's documentation;
+4. pass the CI pipeline;
+5. have signed our
+   [Contributor License Agreement](https://cla-assistant.io/ory/hydra-maester);
+6. include a proper git commit message following the
+   [Conventional Commit Specification](https://www.conventionalcommits.org/en/v1.0.0/).
+
+If all of these items are checked, the pull request is ready to be reviewed and
+you should change the status to "Ready for review" and
+[request review from a maintainer](https://docs.github.com/en/github/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/requesting-a-pull-request-review).
+
+Reviewers will approve the pull request once they are satisfied with the patch.
 
 ## Documentation
 
@@ -179,33 +211,6 @@ Please follow these guidelines when formatting source code:
 - Go code should match the output of `gofmt -s` and pass `golangci-lint run`.
 - NodeJS and JavaScript code should be prettified using `npm run format` where
   appropriate.
-
-## Pull request procedure
-
-To make a pull request, you will need a GitHub account; if you are unclear on
-this process, see GitHub's documentation on
-[forking](https://help.github.com/articles/fork-a-repo) and
-[pull requests](https://help.github.com/articles/using-pull-requests). Pull
-requests should be targeted at the `master` branch. Before creating a pull
-request, go through this checklist:
-
-1. Create a feature branch off of `master` so that changes do not get mixed up.
-1. [Rebase](http://git-scm.com/book/en/Git-Branching-Rebasing) your local
-   changes against the `master` branch.
-1. Run the full project test suite with the `go test ./...` (or equivalent)
-   command and confirm that it passes.
-1. Run `gofmt -s` (if the project is written in Go).
-1. Ensure that each commit has a descriptive prefix. This ensures a uniform
-   commit history and helps structure the changelog.  
-   Please refer to this
-   [list of prefixes for Ory Oathkeeper Maester](https://github.com/ory/hydra-maester/blob/master/.github/semantic.yml).
-
-Pull requests will be treated as "review requests," and maintainers will give
-feedback on the style and substance of the patch.
-
-Normally, all pull requests must include tests that test your change.
-Occasionally, a change will be very difficult to test for. In those cases,
-please include a note in your commit message explaining why.
 
 ### Working with Forks
 
@@ -250,7 +255,7 @@ community a safe place for you and we've got your back.
   marginalized groups.
 - Private harassment is also unacceptable. No matter who you are, if you feel
   you have been or are being harassed or made uncomfortable by a community
-  member, please contact one of the channel ops or a member of the Ory Ory Oathkeeper Maester
+  member, please contact one of the channel ops or a member of the Ory Ory Hydra Maester
   core team immediately.
 - Likewise any spamming, trolling, flaming, baiting or other attention-stealing
   behaviour is not welcome.


### PR DESCRIPTION
Updated repository templates to https://github.com/ory/meta/commit/0f4b64a2553680782561d30a9eb90c256488b617.