### PR TITLE
chore: update repository template to e424c0a0

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,6 +1,6 @@
 blank_issues_enabled: false
 contact_links:
-  - name: Ory Ory Hydra Maester Forum
+  - name: Ory Ory Oathkeeper Maester Forum
     url: https://github.com/ory/hydra-maester/discussions
     about: Please ask and answer questions here, show your implementations and discuss ideas.
   - name: Ory Chat
@@ -8,4 +8,4 @@ contact_links:
     about: Hang out with other Ory community members to ask and answer questions.
   - name: Ory Support for Business
     url: https://github.com/ory/open-source-support/blob/master/README.md
-    about: Buy professional support for Ory Ory Hydra Maester.
+    about: Buy professional support for Ory Ory Oathkeeper Maester.

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -13,13 +13,21 @@ jobs:
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           stale-issue-message: |
-            Thank you for opening this issue. It appears that the request for more information (e.g. providing the software version, providing logs, ...) has not yet been completed. Therefore this issue will be automatically
-            closed in 7 days, assuming that the issue has been resolved.
-          stale-pr-message: |
-            Thank you for opening this pull request. It appears that a request for e.g. information has not yet been completed. Therefore this issue will be automatically
-            closed in 7 days, assuming that the proposed change is no longer required or has otherwise been resolved.
+            I am marking this issue as stale as it has not received any engagement from the community or maintainers in over half a year. That does not imply that the issue has no merit! If you feel strongly about this issue
+
+            - open a PR referencing and resolving the issue;
+            - leave a comment on it and discuss ideas how you could contribute towards resolving it;
+            - open a new issue with updated details and a plan on resolving the issue.
+
+            We are cleaning up issues every now and then, primarily to keep the 4000+ issues in our backlog in check and to [prevent](https://www.jeffgeerling.com/blog/2020/saying-no-burnout-open-source-maintainer) [maintainer](https://www.jeffgeerling.com/blog/2016/why-i-close-prs-oss-project-maintainer-notes) [burnout](https://docs.brew.sh/Maintainers-Avoiding-Burnout). Burnout in open source maintainership is a [widespread](https://opensource.guide/best-practices/#its-okay-to-hit-pause) and serious issue. It can lead to severe personal and health issues as well as [enabling catastrophic](https://haacked.com/archive/2019/05/28/maintainer-burnout/) [attack vectors](https://www.gradiant.org/en/blog/open-source-maintainer-burnout-as-an-attack-surface/).
+
+            Thank you for your understanding and to anyone who participated in the issue! 🙏✌️
+
+            If you feel strongly about this issues and have ideas on resolving it, please comment. Otherwise it will be closed in 30 days!
           stale-issue-label: 'stale'
-          stale-pr-label: 'stale'
-          only-labels: 'needs more info'
-          days-before-stale: 7
-          days-before-close: 7
+          exempt-issue-labels: 'bug,blocking,docs'
+          days-before-stale: 180
+          days-before-close: 30
+          exempt-milestones: true
+          exempt-assignees: true
+          only-pr-labels: 'stale'

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,7 +8,7 @@ https://github.com/ory/meta/blob/master/templates/repository/common/CONTRIBUTING
 
 -->
 
-# Contributing to Ory Ory Hydra Maester
+# Contributing to Ory Ory Oathkeeper Maester
 
 <!-- START doctoc generated TOC please keep comment here to allow auto update -->
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
@@ -32,8 +32,8 @@ There are many ways in which you can contribute, beyond writing code. The goal
 of this document is to provide a high-level overview of how you can get
 involved.
 
-_Please note_: We take Ory Ory Hydra Maester's security and our users' trust very
-seriously. If you believe you have found a security issue in Ory Ory Hydra Maester,
+_Please note_: We take Ory Ory Oathkeeper Maester's security and our users' trust very
+seriously. If you believe you have found a security issue in Ory Ory Oathkeeper Maester,
 please responsibly disclose by contacting us at security@ory.sh.
 
 First: As a potential contributor, your changes and ideas are welcome at any
@@ -48,9 +48,9 @@ contributions, and don't want a wall of rules to get in the way of that.
 That said, if you want to ensure that a pull request is likely to be merged,
 talk to us! You can find out our thoughts and ensure that your contribution
 won't clash or be obviated by Ory
-Ory Hydra Maester's normal direction. A great way to
+Ory Oathkeeper Maester's normal direction. A great way to
 do this is via
-[Ory Ory Hydra Maester Discussions](https://github.com/ory/meta/discussions)
+[Ory Ory Oathkeeper Maester Discussions](https://github.com/ory/meta/discussions)
 or the [Ory Chat](https://www.ory.sh/chat).
 
 ## FAQ
@@ -59,21 +59,21 @@ or the [Ory Chat](https://www.ory.sh/chat).
   [Ory Community Code of Conduct?](https://github.com/ory/hydra-maester/blob/master/CODE_OF_CONDUCT.md)
 
 - I have a question. Where can I get
-  [answers to questions regarding Ory Ory Hydra Maester?](#communication)
+  [answers to questions regarding Ory Ory Oathkeeper Maester?](#communication)
 
 - I would like to contribute but I am not sure how. Are there
   [easy ways to contribute?](#how-can-i-contribute)
   [Or good first issues?](https://github.com/search?l=&o=desc&q=label%3A%22help+wanted%22+label%3A%22good+first+issue%22+is%3Aopen+user%3Aory+user%3Aory-corp&s=updated&type=Issues)
 
-- I want to talk to other Ory Ory Hydra Maester users.
+- I want to talk to other Ory Ory Oathkeeper Maester users.
   [How can I become a part of the community?](#communication)
 
 - I would like to know what I am agreeing to when I contribute to Ory
-  Ory Hydra Maester.
+  Ory Oathkeeper Maester.
   Does Ory have
   [a Contributors License Agreement?](https://cla-assistant.io/ory/hydra-maester)
 
-- I would like updates about new versions of Ory Ory Hydra Maester.
+- I would like updates about new versions of Ory Ory Oathkeeper Maester.
   [How are new releases announced?](https://ory.us10.list-manage.com/subscribe?u=ffb1a878e4ec6c0ed312a3480&id=f605a41b53)
 
 ## How can I contribute?
@@ -85,7 +85,7 @@ There are many other ways you can contribute without writing any code. Here are
 a few things you can do to help out:
 
 - **Give us a star.** It may not seem like much, but it really makes a
-  difference. This is something that everyone can do to help out Ory Ory Hydra Maester.
+  difference. This is something that everyone can do to help out Ory Ory Oathkeeper Maester.
   Github stars help the project gain visibility and stand out.
 
 - **Join the community.** Sometimes helping people can be as easy as listening
@@ -93,7 +93,7 @@ a few things you can do to help out:
   look at discussions in the forum and take part in our weekly hangout. More
   info on this in [Communication](#communication).
 
-- **Helping with open issues.** We have a lot of open issues for Ory Ory Hydra Maester
+- **Helping with open issues.** We have a lot of open issues for Ory Ory Oathkeeper Maester
   and some of them may lack necessary information, some are duplicates of older
   issues. You can help out by guiding people through the process of filling out
   the issue template, asking for clarifying information, or pointing them to
@@ -112,14 +112,14 @@ a few things you can do to help out:
 We use [Slack](https://www.ory.sh/chat). You are welcome to drop in and ask
 questions, discuss bugs and feature requests, talk to other users of Ory, etc.
 
-Check out [Ory Ory Hydra Maester Discussions](https://github.com/ory/meta/discussions). This is a great place for
+Check out [Ory Ory Oathkeeper Maester Discussions](https://github.com/ory/meta/discussions). This is a great place for
 in-depth discussions and lots of code examples, logs and similar data.
 
 You can also join our community hangout, if you want to speak to the Ory team
 directly or ask some questions. You can find more info on the hangouts in
 [Slack](https://www.ory.sh/chat).
 
-If you want to receive regular notifications about updates to Ory Ory Hydra Maester,
+If you want to receive regular notifications about updates to Ory Ory Oathkeeper Maester,
 consider joining the mailing list. We will _only_ send you vital information on
 the projects that you are interested in.
 
@@ -129,7 +129,7 @@ Also [follow us on twitter](https://twitter.com/orycorp).
 
 Unless you are fixing a known bug, we **strongly** recommend discussing it with
 the core team via a GitHub issue or [in our chat](https://www.ory.sh/chat)
-before getting started to ensure your work is consistent with Ory Ory Hydra Maester's
+before getting started to ensure your work is consistent with Ory Ory Oathkeeper Maester's
 roadmap and architecture.
 
 All contributions are made via pull requests. To make a pull request, you will
@@ -149,7 +149,7 @@ request, go through this checklist:
 1. Ensure that each commit has a descriptive prefix. This ensures a uniform
    commit history and helps structure the changelog.  
    Please refer to this
-   [list of prefixes for Ory Hydra Maester](https://github.com/ory/hydra-maester/blob/master/.github/semantic.yml)
+   [list of prefixes for Ory Oathkeeper Maester](https://github.com/ory/hydra-maester/blob/master/.github/semantic.yml)
    for an overview.
 1. Sign-up with CircleCI so that it has access to your repository with the
    branch containing your PR. Simply creating a CircleCI account is sufficient
@@ -255,7 +255,7 @@ community a safe place for you and we've got your back.
   marginalized groups.
 - Private harassment is also unacceptable. No matter who you are, if you feel
   you have been or are being harassed or made uncomfortable by a community
-  member, please contact one of the channel ops or a member of the Ory Ory Hydra Maester
+  member, please contact one of the channel ops or a member of the Ory Ory Oathkeeper Maester
   core team immediately.
 - Likewise any spamming, trolling, flaming, baiting or other attention-stealing
   behaviour is not welcome.


### PR DESCRIPTION
Updated repository templates to https://github.com/ory/meta/commit/e424c0a0a2dd85c585c0be32e8ada257c3fe8021.