### PR TITLE
feat: customize name of secret

### DIFF
--- a/controllers/oauth2client_controller.go
+++ b/controllers/oauth2client_controller.go
@@ -6,6 +6,7 @@ package controllers
 import (
 	"context"
 	"fmt"
+	"os"
 	"sync"
 
 	"github.com/go-logr/logr"
@@ -22,11 +23,16 @@ import (
 )
 
 const (
-	ClientIDKey     = "client_id"
-	ClientSecretKey = "client_secret"
-	FinalizerName   = "finalizer.ory.hydra.sh"
+	DefaultClientID  = "CLIENT_ID"
+	DefaultSecretKey = "CLIENT_SECRET"
+	FinalizerName    = "finalizer.ory.hydra.sh"
 
 	DefaultNamespace = "default"
+)
+
+var (
+	ClientIDKey     = DefaultClientID
+	ClientSecretKey = DefaultSecretKey
 )
 
 type clientKey struct {
@@ -65,6 +71,15 @@ type Options struct {
 
 // Option is a functional option.
 type Option func(*Options)
+
+func init() {
+	if os.Getenv("CLIENT_ID_KEY") != "" {
+		ClientIDKey = os.Getenv("CLIENT_ID_KEY")
+	}
+	if os.Getenv("CLIENT_SECRET_KEY") != "" {
+		ClientSecretKey = os.Getenv("CLIENT_SECRET_KEY")
+	}
+}
 
 // WithNamespace sets the kubernetes namespace for the controller.
 // The default is "default".


### PR DESCRIPTION
## Proposed changes

This pull request introduces the ability to customize `ClientIDKey` and `ClientSecretKey` variables. These variables can now be modified by setting the environment variables `CLIENT_ID_KEY` and `CLIENT_SECRET_KEY` respectively. If these environment variables are not set, the default values (currently "CLIENT_ID" for `ClientIDKey` and "CLIENT_SECRET" for `ClientSecretKey`) will be used.

## Checklist

- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md) and signed the CLA.
- [x] I have referenced an issue containing the design document if my change introduces a new feature.
- [x] I have read the [security policy](../security/policy).
- [x] I confirm that this pull request does not address a security vulnerability. If this pull request addresses a security vulnerability, I confirm that I got approval from the maintainers to push the changes.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have added the necessary documentation within the code base (if appropriate).

## Further comments

In this pull request, I have modified `ClientIDKey` and `ClientSecretKey` to be configurable via environment variables. This allows for greater flexibility in configuring the system, while maintaining sensible defaults.
