### PR TITLE
Implement creating clients with backchannel or frontchannel logout uris

### DIFF
--- a/hydra/client_test.go
+++ b/hydra/client_test.go
@@ -26,11 +26,11 @@ const (
 
 	testID                        = "test-id"
 	testClient                    = `{"client_id":"test-id","owner":"test-name","scope":"some,scopes","grant_types":["type1"],"token_endpoint_auth_method":"client_secret_basic"}`
-	testClientCreated             = `{"client_id":"test-id-2","client_secret":"TmGkvcY7k526","owner":"test-name-2","scope":"some,other,scopes","grant_types":["type2"],"audience":["audience-a","audience-b"],"token_endpoint_auth_method":"client_secret_basic"}`
+	testClientCreated             = `{"client_id":"test-id-2","client_secret":"TmGkvcY7k526","owner":"test-name-2","scope":"some,other,scopes","grant_types":["type2"],"audience":["audience-a","audience-b"],"token_endpoint_auth_method":"client_secret_basic","backchannel_logout_uri":"https://localhost/backchannel-logout","frontchannel_logout_uri":"https://localhost/frontchannel-logout"}`
 	testClientUpdated             = `{"client_id":"test-id-3","client_secret":"xFoPPm654por","owner":"test-name-3","scope":"yet,another,scope","grant_types":["type3"],"audience":["audience-c"],"token_endpoint_auth_method":"client_secret_basic"}`
 	testClientList                = `{"client_id":"test-id-4","owner":"test-name-4","scope":"scope1 scope2","grant_types":["type4"],"token_endpoint_auth_method":"client_secret_basic"}`
 	testClientList2               = `{"client_id":"test-id-5","owner":"test-name-5","scope":"scope3 scope4","grant_types":["type5"],"token_endpoint_auth_method":"client_secret_basic"}`
-	testClientWithMetadataCreated = `{"client_id":"test-id-21","client_secret":"TmGkvcY7k526","owner":"test-name-21","scope":"some,other,scopes","grant_types":["type2"],"token_endpoint_auth_method":"client_secret_basic","metadata":{"property1":1,"property2":"2"}}`
+	testClientWithMetadataCreated = `{"client_id":"test-id-21","client_secret":"TmGkvcY7k526","owner":"test-name-21","scope":"some,other,scopes","grant_types":["type2"],"token_endpoint_auth_method":"client_secret_basic","metadata":{"property1":1,"property2":"2"},"backchannel_logout_uri":"https://localhost/backchannel-logout","frontchannel_logout_uri":"https://localhost/frontchannel-logout"}`
 
 	statusNotFoundBody            = `{"error":"Not Found","error_description":"Unable to locate the requested resource","status_code":404,"request_id":"id"}`
 	statusUnauthorizedBody        = `{"error":"The request could not be authorized","error_description":"The requested OAuth 2.0 client does not exist or you did not provide the necessary credentials","status_code":401,"request_id":"id"}`
@@ -45,10 +45,14 @@ type server struct {
 }
 
 var testOAuthJSONPost = &hydra.OAuth2ClientJSON{
-	Scope:      "some,other,scopes",
-	GrantTypes: []string{"type2"},
-	Owner:      "test-name-2",
-	Audience:   []string{"audience-a", "audience-b"},
+	Scope:                             "some,other,scopes",
+	GrantTypes:                        []string{"type2"},
+	Owner:                             "test-name-2",
+	Audience:                          []string{"audience-a", "audience-b"},
+	FrontChannelLogoutURI:             "https://localhost/frontchannel-logout",
+	FrontChannelLogoutSessionRequired: false,
+	BackChannelLogoutURI:              "https://localhost/backchannel-logout",
+	BackChannelLogoutSessionRequired:  false,
 }
 
 var testOAuthJSONPut = &hydra.OAuth2ClientJSON{
@@ -182,10 +186,14 @@ func TestCRUD(t *testing.T) {
 						"property2": "2",
 					})
 					var testOAuthJSONPost2 = &hydra.OAuth2ClientJSON{
-						Scope:      "some,other,scopes",
-						GrantTypes: []string{"type2"},
-						Owner:      "test-name-21",
-						Metadata:   meta,
+						Scope:                             "some,other,scopes",
+						GrantTypes:                        []string{"type2"},
+						Owner:                             "test-name-21",
+						Metadata:                          meta,
+						FrontChannelLogoutURI:             "https://localhost/frontchannel-logout",
+						FrontChannelLogoutSessionRequired: false,
+						BackChannelLogoutURI:              "https://localhost/backchannel-logout",
+						BackChannelLogoutSessionRequired:  false,
 					}
 					o, err = c.PostOAuth2Client(testOAuthJSONPost2)
 					expected = testOAuthJSONPost2
@@ -211,6 +219,10 @@ func TestCRUD(t *testing.T) {
 					assert.NotNil(o.Secret)
 					assert.NotNil(o.ClientID)
 					assert.NotNil(o.TokenEndpointAuthMethod)
+					assert.Equal(expected.FrontChannelLogoutURI, o.FrontChannelLogoutURI)
+					assert.Equal(expected.FrontChannelLogoutSessionRequired, o.FrontChannelLogoutSessionRequired)
+					assert.Equal(expected.BackChannelLogoutURI, o.BackChannelLogoutURI)
+					assert.Equal(expected.BackChannelLogoutSessionRequired, o.BackChannelLogoutSessionRequired)
 					if expected.TokenEndpointAuthMethod != "" {
 						assert.Equal(expected.TokenEndpointAuthMethod, o.TokenEndpointAuthMethod)
 					}

--- a/hydra/types.go
+++ b/hydra/types.go
@@ -14,21 +14,25 @@ import (
 
 // OAuth2ClientJSON represents an OAuth2 client digestible by ORY Hydra
 type OAuth2ClientJSON struct {
-	ClientName              string          `json:"client_name,omitempty"`
-	ClientID                *string         `json:"client_id,omitempty"`
-	Secret                  *string         `json:"client_secret,omitempty"`
-	GrantTypes              []string        `json:"grant_types"`
-	RedirectURIs            []string        `json:"redirect_uris,omitempty"`
-	PostLogoutRedirectURIs  []string        `json:"post_logout_redirect_uris,omitempty"`
-	AllowedCorsOrigins      []string        `json:"allowed_cors_origins,omitempty"`
-	ResponseTypes           []string        `json:"response_types,omitempty"`
-	Audience                []string        `json:"audience,omitempty"`
-	Scope                   string          `json:"scope"`
-	SkipConsent             bool            `json:"skip_consent,omitempty"`
-	Owner                   string          `json:"owner"`
-	TokenEndpointAuthMethod string          `json:"token_endpoint_auth_method,omitempty"`
-	Metadata                json.RawMessage `json:"metadata,omitempty"`
-	JwksUri                 string          `json:"jwks_uri,omitempty"`
+	ClientName                        string          `json:"client_name,omitempty"`
+	ClientID                          *string         `json:"client_id,omitempty"`
+	Secret                            *string         `json:"client_secret,omitempty"`
+	GrantTypes                        []string        `json:"grant_types"`
+	RedirectURIs                      []string        `json:"redirect_uris,omitempty"`
+	PostLogoutRedirectURIs            []string        `json:"post_logout_redirect_uris,omitempty"`
+	AllowedCorsOrigins                []string        `json:"allowed_cors_origins,omitempty"`
+	ResponseTypes                     []string        `json:"response_types,omitempty"`
+	Audience                          []string        `json:"audience,omitempty"`
+	Scope                             string          `json:"scope"`
+	SkipConsent                       bool            `json:"skip_consent,omitempty"`
+	Owner                             string          `json:"owner"`
+	TokenEndpointAuthMethod           string          `json:"token_endpoint_auth_method,omitempty"`
+	Metadata                          json.RawMessage `json:"metadata,omitempty"`
+	JwksUri                           string          `json:"jwks_uri,omitempty"`
+	FrontChannelLogoutSessionRequired bool            `json:"frontchannel_logout_session_required"`
+	FrontChannelLogoutURI             string          `json:"frontchannel_logout_uri"`
+	BackChannelLogoutSessionRequired  bool            `json:"backchannel_logout_session_required"`
+	BackChannelLogoutURI              string          `json:"backchannel_logout_uri"`
 }
 
 // Oauth2ClientCredentials represents client ID and password fetched from a
@@ -54,18 +58,22 @@ func FromOAuth2Client(c *hydrav1alpha1.OAuth2Client) (*OAuth2ClientJSON, error) 
 	}
 
 	return &OAuth2ClientJSON{
-		ClientName:              c.Spec.ClientName,
-		GrantTypes:              grantToStringSlice(c.Spec.GrantTypes),
-		ResponseTypes:           responseToStringSlice(c.Spec.ResponseTypes),
-		RedirectURIs:            redirectToStringSlice(c.Spec.RedirectURIs),
-		PostLogoutRedirectURIs:  redirectToStringSlice(c.Spec.PostLogoutRedirectURIs),
-		AllowedCorsOrigins:      redirectToStringSlice(c.Spec.AllowedCorsOrigins),
-		Audience:                c.Spec.Audience,
-		Scope:                   c.Spec.Scope,
-		SkipConsent:             c.Spec.SkipConsent,
-		Owner:                   fmt.Sprintf("%s/%s", c.Name, c.Namespace),
-		TokenEndpointAuthMethod: string(c.Spec.TokenEndpointAuthMethod),
-		Metadata:                meta,
+		ClientName:                        c.Spec.ClientName,
+		GrantTypes:                        grantToStringSlice(c.Spec.GrantTypes),
+		ResponseTypes:                     responseToStringSlice(c.Spec.ResponseTypes),
+		RedirectURIs:                      redirectToStringSlice(c.Spec.RedirectURIs),
+		PostLogoutRedirectURIs:            redirectToStringSlice(c.Spec.PostLogoutRedirectURIs),
+		AllowedCorsOrigins:                redirectToStringSlice(c.Spec.AllowedCorsOrigins),
+		Audience:                          c.Spec.Audience,
+		Scope:                             c.Spec.Scope,
+		SkipConsent:                       c.Spec.SkipConsent,
+		Owner:                             fmt.Sprintf("%s/%s", c.Name, c.Namespace),
+		TokenEndpointAuthMethod:           string(c.Spec.TokenEndpointAuthMethod),
+		Metadata:                          meta,
+		FrontChannelLogoutURI:             c.Spec.BackChannelLogoutURI,
+		FrontChannelLogoutSessionRequired: c.Spec.BackChannelLogoutSessionRequired,
+		BackChannelLogoutSessionRequired:  c.Spec.BackChannelLogoutSessionRequired,
+		BackChannelLogoutURI:              c.Spec.BackChannelLogoutURI,
 	}, nil
 }
 


### PR DESCRIPTION
Clients with a `BackChannelLogoutURI` or `FrontChannelLogoutURI` were not registered with such. More importantly, maester will remove the values during reconciliation. With this change, we enable to use the values regarding frontchannel and backchannel logout.

We already had the items in the CRD. However, these were not respected when creating or updating a client.

<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.

This text will be included in the changelog. If applicable, include links to documentation or pieces of code.
If your change includes breaking changes please add a code block documenting the breaking change:

```
BREAKING CHANGES: This patch changes the behavior of configuration item `foo` to do bar. To keep the existing
behavior please do baz.
```
-->

## Related Issue or Design Document

<!--
If this pull request

1. is a fix for a known bug, link the issue where the bug was reported in the format of `#1234`;
2. is a fix for a previously unknown bug, explain the bug and how to reproduce it in this pull request;
3. implements a new feature, link the issue containing the design document in the format of `#1234`;
4. improves the documentation, no issue reference is required.

Pull requests introducing new features, which do not have a design document linked are more likely to be rejected and take on average 2-8 weeks longer to
get merged.

You can discuss changes with maintainers either in the Github Discussions in this repository or
join the [Ory Chat](https://www.ory.sh/chat).
-->

I consider this to be a bug. We provide the fields in the CRD. However they are not included in the HTTP requests against the API.

Reproduction:

```yaml
apiVersion: hydra.ory.sh/v1alpha1
kind: OAuth2Client
metadata:
  name: frontend
spec:
  grantTypes:
    - client_credentials
  responseTypes:
    - id_token
    - code
  scope: 'openid'
  secretName: oauth-client
  backChannelLogoutURI: https://localhost/api/auth/logout/backchannel
  tokenEndpointAuthMethod: client_secret_basic
``` 

```
curl http://localhost:44455/admin/clients|jq '.[0].backchannel_logout_uri'
``` 

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md) and signed the CLA.
- [x] I have referenced an issue containing the design document if my change introduces a new feature.
- [x] I have read the [security policy](../security/policy).
- [x] I confirm that this pull request does not address a security vulnerability. 
      If this pull request addresses a security vulnerability, 
      I confirm that I got approval (please contact [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push the changes.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have added the necessary documentation within the code base (if appropriate).

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution
you did and what alternatives you considered, etc...
-->
