### PR TITLE
feat: disable oauth2 client deletion

### DIFF
--- a/api/v1alpha1/oauth2client_types.go
+++ b/api/v1alpha1/oauth2client_types.go
@@ -176,7 +176,7 @@ type OAuth2ClientSpec struct {
 
 	// +kubebuilder:validation:Enum=client_secret_basic;client_secret_post;private_key_jwt;none
 	//
-	// Indication which authentication method shoud be used for the token endpoint
+	// Indication which authentication method should be used for the token endpoint
 	TokenEndpointAuthMethod TokenEndpointAuthMethod `json:"tokenEndpointAuthMethod,omitempty"`
 
 	// TokenLifespans is the configuration to use for managing different token lifespans
@@ -219,6 +219,12 @@ type OAuth2ClientSpec struct {
 	//
 	// BackChannelLogoutURI RP URL that will cause the RP to log itself out when sent a Logout Token by the OP
 	BackChannelLogoutURI string `json:"backChannelLogoutURI,omitempty"`
+
+	// +kubebuilder:validation:Enum=1;2
+	//
+	// Indicates if a deleted OAuth2Client custom resource should delete the database row or not.
+	// Value 1 means deletion of the OAuth2 client, value 2 means keep an orphan oauth2 client.
+	DeletionPolicy OAuth2ClientDeletionPolicy `json:"deletionPolicy,omitempty"`
 }
 
 // GrantType represents an OAuth 2.0 grant type
@@ -263,6 +269,14 @@ type OAuth2ClientConditionType string
 
 const (
 	OAuth2ClientConditionReady = "Ready"
+)
+
+// OAuth2ClientDeletionPolicy represents if a deleted oauth2 client object should delete the database row or not.
+type OAuth2ClientDeletionPolicy int
+
+const (
+	OAuth2ClientDeletionPolicyDelete = iota + 1
+	OAuth2ClientDeletionPolicyOrphan
 )
 
 // +kubebuilder:validation:Enum=True;False;Unknown

--- a/api/v1alpha1/oauth2client_types_test.go
+++ b/api/v1alpha1/oauth2client_types_test.go
@@ -109,6 +109,7 @@ func TestCreateAPI(t *testing.T) {
 				"invalid lifespan refresh token access token":       func() { created.Spec.TokenLifespans.RefreshTokenGrantAccessTokenLifespan = "invalid" },
 				"invalid lifespan refresh token id token":           func() { created.Spec.TokenLifespans.RefreshTokenGrantIdTokenLifespan = "invalid" },
 				"invalid lifespan refresh token refresh token":      func() { created.Spec.TokenLifespans.RefreshTokenGrantRefreshTokenLifespan = "invalid" },
+				"invalid deletion policy":                           func() { created.Spec.DeletionPolicy = -1 },
 			} {
 				t.Run(fmt.Sprintf("case=%s", desc), func(t *testing.T) {
 					resetTestClient()

--- a/config/crd/bases/hydra.ory.sh_oauth2clients.yaml
+++ b/config/crd/bases/hydra.ory.sh_oauth2clients.yaml
@@ -76,6 +76,14 @@ spec:
                     ClientName is the human-readable string name of the client
                     to be presented to the end-user during authorization.
                   type: string
+                deletionPolicy:
+                  description: |-
+                    Indicates if a deleted OAuth2Client custom resource should delete the database row or not.
+                    Value 0 means deletion of the OAuth2 client, value 1 means keep an orphan oauth2 client.
+                  enum:
+                    - 0
+                    - 1
+                  type: integer
                 frontChannelLogoutSessionRequired:
                   default: false
                   description:
@@ -238,8 +246,8 @@ spec:
                         - private_key_jwt
                         - none
                   description:
-                    Indication which authentication method shoud be used for the
-                    token endpoint
+                    Indication which authentication method should be used for
+                    the token endpoint
                   type: string
                 tokenLifespans:
                   description: |-

--- a/controllers/oauth2client_controller.go
+++ b/controllers/oauth2client_controller.go
@@ -328,7 +328,6 @@ func (r *OAuth2ClientReconciler) updateRegisteredOAuth2Client(ctx context.Contex
 }
 
 func (r *OAuth2ClientReconciler) unregisterOAuth2Clients(ctx context.Context, c *hydrav1alpha1.OAuth2Client) error {
-
 	// if a required field is empty, that means this is deleted after
 	// the finalizers have done their job, so just return
 	if c.Spec.Scope == "" || c.Spec.SecretName == "" {
@@ -347,6 +346,11 @@ func (r *OAuth2ClientReconciler) unregisterOAuth2Clients(ctx context.Context, c 
 
 	for _, cJSON := range clients {
 		if cJSON.Owner == fmt.Sprintf("%s/%s", c.Name, c.Namespace) {
+			if c.Spec.DeletionPolicy == hydrav1alpha1.OAuth2ClientDeletionPolicyOrphan {
+				// Do not delete the OAuth2 client.
+				r.Log.Info("oauth2 client deletion, leave the row orphan")
+				return nil
+			}
 			if err := h.DeleteOAuth2Client(*cJSON.ClientID); err != nil {
 				return err
 			}


### PR DESCRIPTION
This new feature allows to disable hydra-maester OAuth2 client deletion. It can be a pitfall that, when a Kube CRD gets deleted, the OAuth2 client gets deleted too.

OAuth2 clients can be critical for production environments to work properly, and allowing to delete one when a Kubernetes CRD gets deleted has shown to be brittle for us. The CRDs are can be (temporarily) deleted for various reasons: human error, misconfiguration, etc.)
This feature should make hydra-maester safer.

## Related Issue or Design Document

No issue or design document - it's an implementation attempt of a feature that we would find useful on hydra-maester :)

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [ ] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md) and signed the CLA.
- [ ] I have referenced an issue containing the design document if my change introduces a new feature.
- [ ] I have read the [security policy](../security/policy).
- [ ] I confirm that this pull request does not address a security vulnerability. 
      If this pull request addresses a security vulnerability, 
      I confirm that I got approval (please contact [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push the changes.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added the necessary documentation within the code base (if appropriate).

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution
you did and what alternatives you considered, etc...
-->
