### PR TITLE
Allow scope to be passed as array

### DIFF
--- a/api/v1alpha1/oauth2client_types.go
+++ b/api/v1alpha1/oauth2client_types.go
@@ -146,8 +146,9 @@ type OAuth2ClientSpec struct {
 	Audience []string `json:"audience,omitempty"`
 
 	// +kubebuilder:validation:Pattern=([a-zA-Z0-9\.\*]+\s?)*
+	// +kubebuilder:deprecatedversion:warning="Property scope is deprecated. Use scopeArray instead."
 	//
-	// [DEPRECATED] Scope is a string containing a space-separated list of scope values (as
+	// Scope is a string containing a space-separated list of scope values (as
 	// described in Section 3.3 of OAuth 2.0 [RFC6749]) that the client
 	// can use when requesting access tokens.
 	// Use scopeArray instead.

--- a/api/v1alpha1/oauth2client_types.go
+++ b/api/v1alpha1/oauth2client_types.go
@@ -147,13 +147,14 @@ type OAuth2ClientSpec struct {
 
 	// +kubebuilder:validation:Pattern=([a-zA-Z0-9\.\*]+\s?)*
 	//
-	// Scope is a string containing a space-separated list of scope values (as
+	// [DEPRECATED] Scope is a string containing a space-separated list of scope values (as
 	// described in Section 3.3 of OAuth 2.0 [RFC6749]) that the client
 	// can use when requesting access tokens.
+	// Use scopeArray instead.
 	Scope string `json:"scope,omitempty"`
 
-	// ScopeArray is an array of scope values that the client can use when requesting access tokens.
-	// It overrides the property Scope.
+	// Scope is an array of scope values (as described in Section 3.3 of OAuth 2.0 [RFC6749])
+	// that the client can use when requesting access tokens.
 	ScopeArray []string `json:"scopeArray,omitempty"`
 
 	// +kubebuilder:validation:MinLength=1

--- a/api/v1alpha1/oauth2client_types.go
+++ b/api/v1alpha1/oauth2client_types.go
@@ -145,12 +145,16 @@ type OAuth2ClientSpec struct {
 	// Audience is a whitelist defining the audiences this client is allowed to request tokens for
 	Audience []string `json:"audience,omitempty"`
 
-	// +kubebuilder:validation:Pattern=([a-zA-Z0-9\.\*]+\s?)+
+	// +kubebuilder:validation:Pattern=([a-zA-Z0-9\.\*]+\s?)*
 	//
 	// Scope is a string containing a space-separated list of scope values (as
 	// described in Section 3.3 of OAuth 2.0 [RFC6749]) that the client
 	// can use when requesting access tokens.
-	Scope string `json:"scope"`
+	Scope string `json:"scope,omitempty"`
+
+	// ScopeArray is an array of scope values that the client can use when requesting access tokens.
+	// It overrides the property Scope.
+	ScopeArray []string `json:"scopeArray,omitempty"`
 
 	// +kubebuilder:validation:MinLength=1
 	// +kubebuilder:validation:MaxLength=253

--- a/api/v1alpha1/oauth2client_types_test.go
+++ b/api/v1alpha1/oauth2client_types_test.go
@@ -92,7 +92,6 @@ func TestCreateAPI(t *testing.T) {
 				"invalid grant type":                                func() { created.Spec.GrantTypes = []GrantType{"invalid"} },
 				"invalid response type":                             func() { created.Spec.ResponseTypes = []ResponseType{"invalid", "code"} },
 				"invalid composite response type":                   func() { created.Spec.ResponseTypes = []ResponseType{"invalid code", "code id_token"} },
-				"invalid scope":                                     func() { created.Spec.Scope = "" },
 				"missing secret name":                               func() { created.Spec.SecretName = "" },
 				"invalid redirect URI":                              func() { created.Spec.RedirectURIs = []RedirectURI{"invalid"} },
 				"invalid logout redirect URI":                       func() { created.Spec.PostLogoutRedirectURIs = []RedirectURI{"invalid"} },

--- a/api/v1alpha1/zz_generated.deepcopy.go
+++ b/api/v1alpha1/zz_generated.deepcopy.go
@@ -147,6 +147,11 @@ func (in *OAuth2ClientSpec) DeepCopyInto(out *OAuth2ClientSpec) {
 		*out = make([]string, len(*in))
 		copy(*out, *in)
 	}
+	if in.ScopeArray != nil {
+		in, out := &in.ScopeArray, &out.ScopeArray
+		*out = make([]string, len(*in))
+		copy(*out, *in)
+	}
 	out.HydraAdmin = in.HydraAdmin
 	out.TokenLifespans = in.TokenLifespans
 	in.Metadata.DeepCopyInto(&out.Metadata)

--- a/config/crd/bases/hydra.ory.sh_oauth2clients.yaml
+++ b/config/crd/bases/hydra.ory.sh_oauth2clients.yaml
@@ -199,15 +199,16 @@ spec:
                   type: array
                 scope:
                   description: |-
-                    Scope is a string containing a space-separated list of scope values (as
+                    [DEPRECATED] Scope is a string containing a space-separated list of scope values (as
                     described in Section 3.3 of OAuth 2.0 [RFC6749]) that the client
                     can use when requesting access tokens.
+                    Use scopeArray instead.
                   pattern: ([a-zA-Z0-9\.\*]+\s?)*
                   type: string
                 scopeArray:
                   description: |-
-                    ScopeArray is an array of scope values that the client can use when requesting access tokens.
-                    It overrides the property Scope.
+                    Scope is an array of scope values (as described in Section 3.3 of OAuth 2.0 [RFC6749])
+                    that the client can use when requesting access tokens.
                   items:
                     type: string
                   type: array

--- a/config/crd/bases/hydra.ory.sh_oauth2clients.yaml
+++ b/config/crd/bases/hydra.ory.sh_oauth2clients.yaml
@@ -202,8 +202,15 @@ spec:
                     Scope is a string containing a space-separated list of scope values (as
                     described in Section 3.3 of OAuth 2.0 [RFC6749]) that the client
                     can use when requesting access tokens.
-                  pattern: ([a-zA-Z0-9\.\*]+\s?)+
+                  pattern: ([a-zA-Z0-9\.\*]+\s?)*
                   type: string
+                scopeArray:
+                  description: |-
+                    ScopeArray is an array of scope values that the client can use when requesting access tokens.
+                    It overrides the property Scope.
+                  items:
+                    type: string
+                  type: array
                 secretName:
                   description:
                     SecretName points to the K8s secret that contains this
@@ -301,7 +308,6 @@ spec:
                   type: object
               required:
                 - grantTypes
-                - scope
                 - secretName
               type: object
             status:

--- a/config/crd/bases/hydra.ory.sh_oauth2clients.yaml
+++ b/config/crd/bases/hydra.ory.sh_oauth2clients.yaml
@@ -199,7 +199,7 @@ spec:
                   type: array
                 scope:
                   description: |-
-                    [DEPRECATED] Scope is a string containing a space-separated list of scope values (as
+                    Scope is a string containing a space-separated list of scope values (as
                     described in Section 3.3 of OAuth 2.0 [RFC6749]) that the client
                     can use when requesting access tokens.
                     Use scopeArray instead.

--- a/controllers/suite_test.go
+++ b/controllers/suite_test.go
@@ -90,6 +90,7 @@ func StartTestManager(mgr manager.Manager) context.Context {
 	ctx := context.Background()
 
 	go func() {
+		defer GinkgoRecover()
 		defer ctx.Done()
 		Expect(mgr.Start(ctx)).NotTo(HaveOccurred())
 	}()

--- a/hydra/types.go
+++ b/hydra/types.go
@@ -6,6 +6,7 @@ package hydra
 import (
 	"encoding/json"
 	"fmt"
+	"strings"
 
 	"k8s.io/utils/ptr"
 
@@ -67,6 +68,15 @@ func FromOAuth2Client(c *hydrav1alpha1.OAuth2Client) (*OAuth2ClientJSON, error) 
 		return nil, fmt.Errorf("unable to encode `metadata` property value to json: %w", err)
 	}
 
+	var scope = c.Spec.Scope
+	if c.Spec.ScopeArray != nil && c.Spec.Scope != "" {
+		fmt.Println("Warning: both `scope` and `scopeArray` are set. Using `scopeArray`")
+	}
+
+	if c.Spec.ScopeArray != nil {
+		scope = strings.Join(c.Spec.ScopeArray, " ")
+	}
+
 	return &OAuth2ClientJSON{
 		ClientName:                        c.Spec.ClientName,
 		GrantTypes:                        grantToStringSlice(c.Spec.GrantTypes),
@@ -75,7 +85,7 @@ func FromOAuth2Client(c *hydrav1alpha1.OAuth2Client) (*OAuth2ClientJSON, error) 
 		PostLogoutRedirectURIs:            redirectToStringSlice(c.Spec.PostLogoutRedirectURIs),
 		AllowedCorsOrigins:                redirectToStringSlice(c.Spec.AllowedCorsOrigins),
 		Audience:                          c.Spec.Audience,
-		Scope:                             c.Spec.Scope,
+		Scope:                             scope,
 		SkipConsent:                       c.Spec.SkipConsent,
 		Owner:                             fmt.Sprintf("%s/%s", c.Name, c.Namespace),
 		TokenEndpointAuthMethod:           string(c.Spec.TokenEndpointAuthMethod),

--- a/hydra/types.go
+++ b/hydra/types.go
@@ -68,13 +68,13 @@ func FromOAuth2Client(c *hydrav1alpha1.OAuth2Client) (*OAuth2ClientJSON, error) 
 		return nil, fmt.Errorf("unable to encode `metadata` property value to json: %w", err)
 	}
 
-	var scope = c.Spec.Scope
-	if c.Spec.ScopeArray != nil && c.Spec.Scope != "" {
-		fmt.Println("Warning: both `scope` and `scopeArray` are set. Using `scopeArray`")
+	if c.Spec.Scope != "" {
+		fmt.Println("Property `scope` in client '" + c.Name + "' is deprecated. Rather use scopeArray.")
 	}
 
+	var scope = c.Spec.Scope
 	if c.Spec.ScopeArray != nil {
-		scope = strings.Join(c.Spec.ScopeArray, " ")
+		scope = strings.Trim(strings.Join(c.Spec.ScopeArray, " ")+" "+scope, " ")
 	}
 
 	return &OAuth2ClientJSON{

--- a/hydra/types_test.go
+++ b/hydra/types_test.go
@@ -1,0 +1,29 @@
+// Copyright © 2024 Ory Corp
+// SPDX-License-Identifier: Apache-2.0
+
+package hydra_test
+
+import (
+	"testing"
+
+	hydrav1alpha1 "github.com/ory/hydra-maester/api/v1alpha1"
+	"github.com/ory/hydra-maester/hydra"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestTypes(t *testing.T) {
+	t.Run("Test ScopeArray", func(t *testing.T) {
+		c := hydrav1alpha1.OAuth2Client{
+			Spec: hydrav1alpha1.OAuth2ClientSpec{
+				ScopeArray: []string{"scope1", "scope2"},
+			},
+		}
+
+		var parsedClient, err = hydra.FromOAuth2Client(&c)
+		if err != nil {
+			assert.Fail(t, "unexpected error: %s", err)
+		}
+
+		assert.Equal(t, parsedClient.Scope, "scope1 scope2")
+	})
+}

--- a/hydra/types_test.go
+++ b/hydra/types_test.go
@@ -26,4 +26,20 @@ func TestTypes(t *testing.T) {
 
 		assert.Equal(t, parsedClient.Scope, "scope1 scope2")
 	})
+
+	t.Run("Test having both Scope and ScopeArray", func(t *testing.T) {
+		c := hydrav1alpha1.OAuth2Client{
+			Spec: hydrav1alpha1.OAuth2ClientSpec{
+				Scope:      "scope3",
+				ScopeArray: []string{"scope1", "scope2"},
+			},
+		}
+
+		var parsedClient, err = hydra.FromOAuth2Client(&c)
+		if err != nil {
+			assert.Fail(t, "unexpected error: %s", err)
+		}
+
+		assert.Equal(t, parsedClient.Scope, "scope1 scope2 scope3")
+	})
 }


### PR DESCRIPTION
<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.

This text will be included in the changelog. If applicable, include links to documentation or pieces of code.
If your change includes breaking changes please add a code block documenting the breaking change:

```
BREAKING CHANGES: This patch changes the behavior of configuration item `foo` to do bar. To keep the existing
behavior please do baz.
```
-->

Scopes are currently passed as a scope string, separating scopes by spaces.
Clients can grow to many scopes, resulting in a very long string.

This change allows us to specify scopes using the property scopeArray. That way, we can separate scopes by newlines.
Additionally, this allows us to comment a single scope temporarily or add a comment for a specific scope, e.g. as a reason why that client has this scope granted.

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md) and signed the CLA.
- [ ] I have referenced an issue containing the design document if my change introduces a new feature.
- [x] I have read the [security policy](../security/policy).
- [x] I confirm that this pull request does not address a security vulnerability. 
      If this pull request addresses a security vulnerability, 
      I confirm that I got approval (please contact [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push the changes.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have added the necessary documentation within the code base (if appropriate). -- Is kubectl explain enough?
