### PR TITLE
chore: increase HydraAdmin.URL maxLength to 256 and add failing test for too-long URLs

### DIFF
--- a/api/v1alpha1/oauth2client_types.go
+++ b/api/v1alpha1/oauth2client_types.go
@@ -20,7 +20,7 @@ const (
 
 // HydraAdmin defines the desired hydra admin instance to use for OAuth2Client
 type HydraAdmin struct {
-	// +kubebuilder:validation:MaxLength=64
+	// +kubebuilder:validation:MaxLength=256
 	// +kubebuilder:validation:Pattern=`(^$|^https?://.*)`
 	//
 	// URL is the URL for the hydra instance on

--- a/api/v1alpha1/oauth2client_types_test.go
+++ b/api/v1alpha1/oauth2client_types_test.go
@@ -6,6 +6,7 @@ package v1alpha1
 import (
 	"fmt"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -96,6 +97,7 @@ func TestCreateAPI(t *testing.T) {
 				"invalid redirect URI":                              func() { created.Spec.RedirectURIs = []RedirectURI{"invalid"} },
 				"invalid logout redirect URI":                       func() { created.Spec.PostLogoutRedirectURIs = []RedirectURI{"invalid"} },
 				"invalid hydra url":                                 func() { created.Spec.HydraAdmin.URL = "invalid" },
+				"invalid hydra url too long":                        func() { created.Spec.HydraAdmin.URL = "https://" + strings.Repeat("a", 260) },
 				"invalid hydra port high":                           func() { created.Spec.HydraAdmin.Port = 65536 },
 				"invalid hydra endpoint":                            func() { created.Spec.HydraAdmin.Endpoint = "invalid" },
 				"invalid hydra forwarded proto":                     func() { created.Spec.HydraAdmin.ForwardedProto = "invalid" },

--- a/config/crd/bases/hydra.ory.sh_oauth2clients.yaml
+++ b/config/crd/bases/hydra.ory.sh_oauth2clients.yaml
@@ -150,7 +150,7 @@ spec:
                         URL is the URL for the hydra instance on
                         which to set up the client. This value will override the value
                         provided to `--hydra-url`
-                      maxLength: 64
+                      maxLength: 256
                       pattern: (^$|^https?://.*)
                       type: string
                   type: object


### PR DESCRIPTION
## What
- Increase the `maxLength` validation of `HydraAdmin.URL` from **64** to **256** characters in the CRD.  
- Regenerate the CRD schema automatically via `make manifests`.  
- Add a unit test to verify that a valid URL longer than 256 characters is rejected.

## Why
- A full URL (scheme `http(s)://`, port, path, query parameters, etc.) often exceeds 64 characters.  
- The previous limit of 64 likely originated from the maximum length of a DNS label (63), but it doesn’t apply to an entire URL.  
- 256 remains a reasonable cap to control Custom Resource size while covering the vast majority of real‑world URLs.

## How
1. **Go code changes**  
   - In `api/v1alpha1/oauth2client_types.go`, bump the `+kubebuilder:validation:MaxLength` tag to `256`.
2. **CRD regeneration**  
   - Run `make manifests` to update `config/crd/bases/hydra.ory.sh_oauth2clients.yaml`.
3. **Test addition**  
   - In `api/v1alpha1/oauth2client_types_test.go`, import `strings` and add a new test case `"invalid hydra url too long"` that builds an URL of `"https://"+strings.Repeat("a", 260)` and asserts it is rejected.
4. **Verification**  
   - Run `go test ./api/v1alpha1`, which should pass all existing cases and confirm the new over‑length URL case fails as expected.


## Related Issue or Design Document

N/A

## Checklist

- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md) and signed the CLA.
- [x] I have referenced an issue containing the design document if my change introduces a new feature.
- [x] I have read the [security policy](../security/policy).
- [x] I confirm that this pull request does not address a security vulnerability.  
      If this pull request addresses a security vulnerability,  
      I confirm that I got approval (please contact [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push the changes.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have added the necessary documentation within the code base (if appropriate).

## Further comments

We selected 256 as a reasonable upper bound: it accommodates typical URL lengths while still enforcing a cap to protect the API server’s validation cost.
Feedback welcome!  
