### PR TITLE
fix: add timeout to HTTP client

### DIFF
--- a/helpers/http_client.go
+++ b/helpers/http_client.go
@@ -7,6 +7,7 @@ import (
 	"crypto/tls"
 	"net/http"
 	"os"
+	"time"
 
 	ctrl "sigs.k8s.io/controller-runtime"
 
@@ -16,7 +17,9 @@ import (
 func CreateHttpClient(insecureSkipVerify bool, tlsTrustStore string) (*http.Client, error) {
 	setupLog := ctrl.Log.WithName("setup")
 	tr := &http.Transport{}
-	httpClient := &http.Client{}
+	httpClient := &http.Client{
+		Timeout: 5 * time.Second,
+	}
 	if insecureSkipVerify {
 		setupLog.Info("configuring TLS with InsecureSkipVerify")
 		tr.TLSClientConfig = &tls.Config{InsecureSkipVerify: true}


### PR DESCRIPTION
```
fix: add missing timeout to HTTP client to avoid controller getting stuck when interacting with hydra
```

## Related Issue or Design Document

As explained in #276, the default Go's HTTP client has no timeout set by default, which can lead to cases where the controller can get stuck until an underlying TCP connection gets dropped.
The PR fixes the issue by adding a hardcoded 5 second timeout. The number is arbitrary, and I think it should be sufficient to cover pretty much any case.

Fixes: #276

## Checklist

- [X] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md) and signed the CLA.
- [X] I have referenced an issue containing the design document if my change introduces a new feature.
- [X] I have read the [security policy](../security/policy).
- [X] I confirm that this pull request does not address a security vulnerability. 
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added the necessary documentation within the code base (if appropriate).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * HTTP client requests now enforce a 5-second timeout to prevent connection hangs.
  * This reduces stalled network calls and improves overall app responsiveness and stability, especially under unreliable network conditions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ory/hydra-maester/pull/277?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->