### PR TITLE
feat: add requireExistingSecret for OAuth2Client

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@
   - [Design](#design)
   - [How to use it](#how-to-use-it)
     - [Command-line flags](#command-line-flags)
+    - [Environmental Variables](#environmental-variables)
+    - [Externally managed secrets](#externally-managed-secrets)
   - [Development](#development)
     - [Testing](#testing)
 
@@ -66,21 +68,66 @@ To deploy the controller, edit the value of the `--hydra-url` argument in the
 
 ### Command-line flags
 
-| Name                         | Required | Description                                                                                                      | Default value | Example values                           |
-| ---------------------------- | -------- | ---------------------------------------------------------------------------------------------------------------- | ------------- | ---------------------------------------- |
-| **hydra-url**                | yes      | ORY Hydra's service address                                                                                      | -             | ` ory-hydra-admin.ory.svc.cluster.local` |
-| **hydra-port**               | no       | ORY Hydra's service port                                                                                         | `4445`        | `4445`                                   |
-| **tls-trust-store**          | no       | TLS cert path for hydra client                                                                                   | `""`          | `/etc/ssl/certs/ca-certificates.crt`     |
-| **insecure-skip-verify**     | no       | Skip http client insecure verification                                                                           | `false`       | `true` or `false`                        |
-| **namespace**                | no       | Namespace in which the controller should operate. Setting this will make the controller ignore other namespaces. | `""`          | `"my-namespace"`                         |
-| **leader-elector-namespace** | no       | Leader elector namespace where controller should be set.                                                         | `""`          | `"my-namespace"`                         |
+| Name                         | Required | Description                                                                                                                                 | Default value | Example values                           |
+| ---------------------------- | -------- | ------------------------------------------------------------------------------------------------------------------------------------------- | ------------- | ---------------------------------------- |
+| **hydra-url**                | yes      | ORY Hydra's service address                                                                                                                 | -             | ` ory-hydra-admin.ory.svc.cluster.local` |
+| **hydra-port**               | no       | ORY Hydra's service port                                                                                                                    | `4445`        | `4445`                                   |
+| **tls-trust-store**          | no       | TLS cert path for hydra client                                                                                                              | `""`          | `/etc/ssl/certs/ca-certificates.crt`     |
+| **insecure-skip-verify**     | no       | Skip http client insecure verification                                                                                                      | `false`       | `true` or `false`                        |
+| **namespace**                | no       | Namespace in which the controller should operate. Setting this will make the controller ignore other namespaces.                            | `""`          | `"my-namespace"`                         |
+| **leader-elector-namespace** | no       | Leader elector namespace where controller should be set.                                                                                    | `""`          | `"my-namespace"`                         |
+| **require-existing-secret**  | no       | Wait for the secret referenced by an OAuth2Client instead of generating one. See [Externally managed secrets](#externally-managed-secrets). | `false`       | `true` or `false`                        |
 
 ### Environmental Variables
 
-| Variable name           | Default value       | Example value         |
-| :---------------------- | ------------------- | --------------------- |
-| `**CLIENT_ID_KEY**`     | `**CLIENT_ID**`     | `**MY_SECRET_NAME**`  |
-| `**CLIENT_SECRET_KEY**` | `**CLIENT_SECRET**` | `**MY_SECRET_VALUE**` |
+| Variable name                 | Default value       | Example value         |
+| :---------------------------- | ------------------- | --------------------- |
+| `**CLIENT_ID_KEY**`           | `**CLIENT_ID**`     | `**MY_SECRET_NAME**`  |
+| `**CLIENT_SECRET_KEY**`       | `**CLIENT_SECRET**` | `**MY_SECRET_VALUE**` |
+| `**REQUIRE_EXISTING_SECRET**` | `**false**`         | `**true**`            |
+
+### Externally managed secrets
+
+By default, when the secret referenced by `spec.secretName` does not exist, the
+controller registers a new OAuth2 client with a Hydra-generated secret and
+creates that Kubernetes secret itself, owned by the `OAuth2Client` resource.
+
+That is the wrong behaviour when the secret is provisioned by something else,
+for example the External Secrets Operator, sealed-secrets, or any other
+controller syncing it from an external vault. If the `OAuth2Client` reconciles
+before the secret has been materialized, hydra-maester wins the race and the two
+controllers end up fighting over the same secret.
+
+Set `--require-existing-secret` (or `REQUIRE_EXISTING_SECRET=true`) to make the
+controller wait for the secret instead. While the secret is missing, the client
+is not registered in Hydra, no secret is created, and the resource reports:
+
+```yaml
+status:
+  conditions:
+    - type: Ready
+      status: "False"
+  reconciliationError:
+    statusCode: SECRET_NOT_FOUND
+    description: secret my-namespace/hydra-client-oauth2-secret does not exist
+```
+
+The resource is requeued with an exponential backoff, starting at 15 seconds and
+capped at 5 minutes, and reconciles normally as soon as the secret appears.
+
+Individual resources can override the controller-wide default through
+`spec.requireExistingSecret`:
+
+```yaml
+apiVersion: hydra.ory.sh/v1alpha1
+kind: OAuth2Client
+metadata:
+  name: my-oauth2-client
+spec:
+  secretName: hydra-client-oauth2-secret
+  requireExistingSecret: true
+  # ...
+```
 
 ## Development
 

--- a/api/v1alpha1/oauth2client_types.go
+++ b/api/v1alpha1/oauth2client_types.go
@@ -16,6 +16,7 @@ const (
 	StatusUpdateFailed        StatusCode = "CLIENT_UPDATE_FAILED"
 	StatusInvalidSecret       StatusCode = "INVALID_SECRET"
 	StatusInvalidHydraAddress StatusCode = "INVALID_HYDRA_ADDRESS"
+	StatusSecretNotFound      StatusCode = "SECRET_NOT_FOUND"
 )
 
 // HydraAdmin defines the desired hydra admin instance to use for OAuth2Client
@@ -167,6 +168,16 @@ type OAuth2ClientSpec struct {
 	//
 	// SecretName points to the K8s secret that contains this client's ID and password
 	SecretName string `json:"secretName"`
+
+	// +kubebuilder:validation:type=bool
+	// +optional
+	//
+	// RequireExistingSecret makes the controller wait for the secret referenced by
+	// secretName instead of registering the client with a Hydra-generated secret and
+	// creating that secret itself. Use this when the secret is provisioned by another
+	// controller, e.g. the External Secrets Operator. If unset, the controller-wide
+	// `--require-existing-secret` flag applies.
+	RequireExistingSecret *bool `json:"requireExistingSecret,omitempty"`
 
 	// SkipConsent skips the consent screen for this client.
 	// +kubebuilder:validation:type=bool

--- a/api/v1alpha1/zz_generated.deepcopy.go
+++ b/api/v1alpha1/zz_generated.deepcopy.go
@@ -157,6 +157,11 @@ func (in *OAuth2ClientSpec) DeepCopyInto(out *OAuth2ClientSpec) {
 		*out = make([]string, len(*in))
 		copy(*out, *in)
 	}
+	if in.RequireExistingSecret != nil {
+		in, out := &in.RequireExistingSecret, &out.RequireExistingSecret
+		*out = new(bool)
+		**out = **in
+	}
 	out.HydraAdmin = in.HydraAdmin
 	out.TokenLifespans = in.TokenLifespans
 	in.Metadata.DeepCopyInto(&out.Metadata)

--- a/config/crd/bases/hydra.ory.sh_oauth2clients.yaml
+++ b/config/crd/bases/hydra.ory.sh_oauth2clients.yaml
@@ -14,411 +14,449 @@ spec:
     singular: oauth2client
   scope: Namespaced
   versions:
-  - name: v1alpha1
-    schema:
-      openAPIV3Schema:
-        description: OAuth2Client is the Schema for the oauth2clients API
-        properties:
-          apiVersion:
-            description: |-
-              APIVersion defines the versioned schema of this representation of an object.
-              Servers should convert recognized schemas to the latest internal value, and
-              may reject unrecognized values.
-              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-            type: string
-          kind:
-            description: |-
-              Kind is a string value representing the REST resource this object represents.
-              Servers may infer this from the endpoint the client submits requests to.
-              Cannot be updated.
-              In CamelCase.
-              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-            type: string
-          metadata:
-            type: object
-          spec:
-            description: OAuth2ClientSpec defines the desired state of OAuth2Client
-            properties:
-              accessTokenStrategy:
-                description: AccessTokenStrategy is the OAuth 2.0 Access Token Strategy
-                enum:
-                - jwt
-                - opaque
-                type: string
-              allowedCorsOrigins:
-                description: AllowedCorsOrigins is an array of allowed CORS origins
-                items:
-                  description: RedirectURI represents a redirect URI for the client
-                  pattern: \w+:/?/?[^\s]+
-                  type: string
-                type: array
-              audience:
-                description: Audience is a whitelist defining the audiences this client
-                  is allowed to request tokens for
-                items:
-                  type: string
-                type: array
-              backChannelLogoutSessionRequired:
-                default: false
-                description: BackChannelLogoutSessionRequired Boolean value specifying
-                  whether the RP requires that a sid (session ID) Claim be included
-                  in the Logout Token to identify the RP session with the OP when
-                  the backchannel_logout_uri is used. If omitted, the default value
-                  is false.
-                type: boolean
-              backChannelLogoutURI:
-                description: BackChannelLogoutURI RP URL that will cause the RP to
-                  log itself out when sent a Logout Token by the OP
-                pattern: (^$|^https?://.*)
-                type: string
-              clientName:
-                description: ClientName is the human-readable string name of the client
-                  to be presented to the end-user during authorization.
-                type: string
-              clientSecretExpiresAt:
-                description: ClientSecretExpiresAt is the timestamp when the client
-                  secret expires (currently always 0)
-                format: int64
-                minimum: 0
-                type: integer
-              clientUri:
-                description: ClientUri is a URL string of a web page providing information
-                  about the client
-                pattern: (^$|^https?://.*)
-                type: string
-              contacts:
-                description: Contacts is an array of strings representing ways to
-                  contact people responsible for this client
-                items:
-                  type: string
-                type: array
-              deletionPolicy:
-                description: |-
-                  Indicates if a deleted OAuth2Client custom resource should delete the database row or not.
-                  Values can be 'delete' to delete the OAuth2 client, value 'orphan' to keep an orphan oauth2 client.
-                enum:
-                - delete
-                - orphan
-                type: string
-              frontChannelLogoutSessionRequired:
-                default: false
-                description: FrontChannelLogoutSessionRequired Boolean value specifying
-                  whether the RP requires that iss (issuer) and sid (session ID) query
-                  parameters be included to identify the RP session with the OP when
-                  the frontchannel_logout_uri is used
-                type: boolean
-              frontChannelLogoutURI:
-                description: FrontChannelLogoutURI RP URL that will cause the RP to
-                  log itself out when rendered in an iframe by the OP. An iss (issuer)
-                  query parameter and a sid (session ID) query parameter MAY be included
-                  by the OP to enable the RP to validate the request and to determine
-                  which of the potentially multiple sessions is to be logged out;
-                  if either is included, both MUST be
-                pattern: (^$|^https?://.*)
-                type: string
-              grantTypes:
-                description: GrantTypes is an array of grant types the client is allowed
-                  to use.
-                items:
-                  description: GrantType represents an OAuth 2.0 grant type
-                  enum:
-                  - client_credentials
-                  - authorization_code
-                  - implicit
-                  - refresh_token
-                  type: string
-                maxItems: 4
-                minItems: 1
-                type: array
-              hydraAdmin:
-                description: |-
-                  HydraAdmin is the optional configuration to use for managing
-                  this client
-                properties:
-                  endpoint:
-                    description: |-
-                      Endpoint is the endpoint for the hydra instance on which
-                      to set up the client. This value will override the value
-                      provided to `--endpoint` (defaults to `"/clients"` in the
-                      application)
-                    pattern: (^$|^/.*)
-                    type: string
-                  forwardedProto:
-                    description: |-
-                      ForwardedProto overrides the `--forwarded-proto` flag. The
-                      value "off" will force this to be off even if
-                      `--forwarded-proto` is specified
-                    pattern: (^$|https?|off)
-                    type: string
-                  port:
-                    description: |-
-                      Port is the port for the hydra instance on
-                      which to set up the client. This value will override the value
-                      provided to `--hydra-port`
-                    maximum: 65535
-                    type: integer
-                  url:
-                    description: |-
-                      URL is the URL for the hydra instance on
-                      which to set up the client. This value will override the value
-                      provided to `--hydra-url`
-                    maxLength: 256
-                    pattern: (^$|^https?://.*)
-                    type: string
-                type: object
-              jwksUri:
-                description: JwksUri Define the URL where the JSON Web Key Set should
-                  be fetched from when performing the private_key_jwt client authentication
-                  method.
-                pattern: (^$|^https?://.*)
-                type: string
-              logoUri:
-                description: |-
-                  LogoUri is the URI to the logo of the client.
-                  This is used to display the logo in the consent screen.
-                  It should be a valid URL pointing to an image.
-                pattern: (^$|^https?://.*)
-                type: string
-              metadata:
-                description: Metadata is arbitrary data
-                nullable: true
-                type: object
-                x-kubernetes-preserve-unknown-fields: true
-              policyUri:
-                description: PolicyUri is a URL string that points to a human-readable
-                  privacy policy document
-                pattern: (^$|^https?://.*)
-                type: string
-              postLogoutRedirectUris:
-                description: PostLogoutRedirectURIs is an array of the post logout
-                  redirect URIs allowed for the application
-                items:
-                  description: RedirectURI represents a redirect URI for the client
-                  pattern: \w+:/?/?[^\s]+
-                  type: string
-                type: array
-              redirectUris:
-                description: RedirectURIs is an array of the redirect URIs allowed
-                  for the application
-                items:
-                  description: RedirectURI represents a redirect URI for the client
-                  pattern: \w+:/?/?[^\s]+
-                  type: string
-                type: array
-              requestObjectSigningAlg:
-                description: RequestObjectSigningAlg is the algorithm that must be
-                  used for signing request objects
-                type: string
-              requestUris:
-                description: RequestURIs is an array of request URIs that can be used
-                  in authorization requests
-                items:
-                  description: RedirectURI represents a redirect URI for the client
-                  pattern: \w+:/?/?[^\s]+
-                  type: string
-                type: array
-              requireExistingSecret:
-                description: |-
-                  RequireExistingSecret makes the controller wait for the secret referenced by
-                  secretName instead of registering the client with a Hydra-generated secret and
-                  creating that secret itself. Use this when the secret is provisioned by another
-                  controller, e.g. the External Secrets Operator. If unset, the controller-wide
-                  `--require-existing-secret` flag applies.
-                type: boolean
-              responseTypes:
-                description: |-
-                  ResponseTypes is an array of the OAuth 2.0 response type strings that the client can
-                  use at the authorization endpoint.
-                items:
-                  description: ResponseType represents an OAuth 2.0 response type
-                    strings
-                  enum:
-                  - id_token
-                  - code
-                  - token
-                  - code token
-                  - code id_token
-                  - id_token token
-                  - code id_token token
-                  type: string
-                maxItems: 3
-                minItems: 1
-                type: array
-              scope:
-                description: |-
-                  Scope is a string containing a space-separated list of scope values (as
-                  described in Section 3.3 of OAuth 2.0 [RFC6749]) that the client
-                  can use when requesting access tokens.
-                  Use scopeArray instead.
-                pattern: ([a-zA-Z0-9\.\*]+\s?)*
-                type: string
-              scopeArray:
-                description: |-
-                  Scope is an array of scope values (as described in Section 3.3 of OAuth 2.0 [RFC6749])
-                  that the client can use when requesting access tokens.
-                items:
-                  type: string
-                type: array
-              secretName:
-                description: SecretName points to the K8s secret that contains this
-                  client's ID and password
-                maxLength: 253
-                minLength: 1
-                pattern: '[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*'
-                type: string
-              sectorIdentifierUri:
-                description: SectorIdentifierUri is a URL using the https scheme to
-                  be used in calculating Pseudonymous Identifiers
-                pattern: (^$|^https?://.*)
-                type: string
-              skipConsent:
-                default: false
-                description: SkipConsent skips the consent screen for this client.
-                type: boolean
-              skipLogoutConsent:
-                default: false
-                description: SkipLogoutConsent skips asking the user to confirm the
-                  logout request
-                type: boolean
-              subjectType:
-                description: SubjectType is the requested subject type
-                enum:
-                - public
-                - pairwise
-                type: string
-              tokenEndpointAuthMethod:
-                description: Indication which authentication method should be used
-                  for the token endpoint
-                enum:
-                - client_secret_basic
-                - client_secret_post
-                - private_key_jwt
-                - none
-                type: string
-              tokenEndpointAuthSigningAlg:
-                description: TokenEndpointAuthSigningAlg is the algorithm used to
-                  sign JWT tokens for client authentication
-                type: string
-              tokenLifespans:
-                description: |-
-                  TokenLifespans is the configuration to use for managing different token lifespans
-                  depending on the used grant type.
-                properties:
-                  authorization_code_grant_access_token_lifespan:
-                    description: |-
-                      AuthorizationCodeGrantAccessTokenLifespan is the access token lifespan
-                      issued on an authorization_code grant.
-                    pattern: '[0-9]+(ns|us|ms|s|m|h)'
-                    type: string
-                  authorization_code_grant_id_token_lifespan:
-                    description: |-
-                      AuthorizationCodeGrantIdTokenLifespan is the id token lifespan
-                      issued on an authorization_code grant.
-                    pattern: '[0-9]+(ns|us|ms|s|m|h)'
-                    type: string
-                  authorization_code_grant_refresh_token_lifespan:
-                    description: |-
-                      AuthorizationCodeGrantRefreshTokenLifespan is the refresh token lifespan
-                      issued on an authorization_code grant.
-                    pattern: '[0-9]+(ns|us|ms|s|m|h)'
-                    type: string
-                  client_credentials_grant_access_token_lifespan:
-                    description: |-
-                      AuthorizationCodeGrantRefreshTokenLifespan is the access token lifespan
-                      issued on a client_credentials grant.
-                    pattern: '[0-9]+(ns|us|ms|s|m|h)'
-                    type: string
-                  implicit_grant_access_token_lifespan:
-                    description: |-
-                      ImplicitGrantAccessTokenLifespan is the access token lifespan
-                      issued on an implicit grant.
-                    pattern: '[0-9]+(ns|us|ms|s|m|h)'
-                    type: string
-                  implicit_grant_id_token_lifespan:
-                    description: |-
-                      ImplicitGrantIdTokenLifespan is the id token lifespan
-                      issued on an implicit grant.
-                    pattern: '[0-9]+(ns|us|ms|s|m|h)'
-                    type: string
-                  jwt_bearer_grant_access_token_lifespan:
-                    description: |-
-                      JwtBearerGrantAccessTokenLifespan is the access token lifespan
-                      issued on a jwt_bearer grant.
-                    pattern: '[0-9]+(ns|us|ms|s|m|h)'
-                    type: string
-                  refresh_token_grant_access_token_lifespan:
-                    description: |-
-                      RefreshTokenGrantAccessTokenLifespan is the access token lifespan
-                      issued on a refresh_token grant.
-                    pattern: '[0-9]+(ns|us|ms|s|m|h)'
-                    type: string
-                  refresh_token_grant_id_token_lifespan:
-                    description: |-
-                      RefreshTokenGrantIdTokenLifespan is the id token lifespan
-                      issued on a refresh_token grant.
-                    pattern: '[0-9]+(ns|us|ms|s|m|h)'
-                    type: string
-                  refresh_token_grant_refresh_token_lifespan:
-                    description: |-
-                      RefreshTokenGrantRefreshTokenLifespan is the refresh token lifespan
-                      issued on a refresh_token grant.
-                    pattern: '[0-9]+(ns|us|ms|s|m|h)'
-                    type: string
-                type: object
-              tosUri:
-                description: TosUri is a URL string that points to a human-readable
-                  terms of service document
-                pattern: (^$|^https?://.*)
-                type: string
-              userinfoSignedResponseAlg:
-                description: UserinfoSignedResponseAlg is the algorithm used to sign
-                  UserInfo responses
-                type: string
-            required:
-            - grantTypes
-            - secretName
-            type: object
-          status:
-            description: OAuth2ClientStatus defines the observed state of OAuth2Client
-            properties:
-              conditions:
-                items:
-                  description: OAuth2ClientCondition contains condition information
-                    for an OAuth2Client
-                  properties:
-                    status:
-                      enum:
-                      - "True"
-                      - "False"
-                      - Unknown
-                      type: string
-                    type:
-                      type: string
-                  required:
-                  - status
-                  - type
-                  type: object
-                type: array
-              observedGeneration:
-                description: ObservedGeneration represents the most recent generation
-                  observed by the daemon set controller.
-                format: int64
-                type: integer
-              reconciliationError:
-                description: ReconciliationError represents an error that occurred
-                  during the reconciliation process
-                properties:
+    - name: v1alpha1
+      schema:
+        openAPIV3Schema:
+          description: OAuth2Client is the Schema for the oauth2clients API
+          properties:
+            apiVersion:
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+              type: string
+            kind:
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+              type: string
+            metadata:
+              type: object
+            spec:
+              description:
+                OAuth2ClientSpec defines the desired state of OAuth2Client
+              properties:
+                accessTokenStrategy:
                   description:
-                    description: Description is the description of the reconciliation
-                      error
+                    AccessTokenStrategy is the OAuth 2.0 Access Token Strategy
+                  enum:
+                    - jwt
+                    - opaque
+                  type: string
+                allowedCorsOrigins:
+                  description:
+                    AllowedCorsOrigins is an array of allowed CORS origins
+                  items:
+                    description:
+                      RedirectURI represents a redirect URI for the client
+                    pattern: \w+:/?/?[^\s]+
                     type: string
-                  statusCode:
-                    description: Code is the status code of the reconciliation error
+                  type: array
+                audience:
+                  description:
+                    Audience is a whitelist defining the audiences this client
+                    is allowed to request tokens for
+                  items:
                     type: string
-                type: object
-            type: object
-        type: object
-    served: true
-    storage: true
-    subresources:
-      status: {}
+                  type: array
+                backChannelLogoutSessionRequired:
+                  default: false
+                  description:
+                    BackChannelLogoutSessionRequired Boolean value specifying
+                    whether the RP requires that a sid (session ID) Claim be
+                    included in the Logout Token to identify the RP session with
+                    the OP when the backchannel_logout_uri is used. If omitted,
+                    the default value is false.
+                  type: boolean
+                backChannelLogoutURI:
+                  description:
+                    BackChannelLogoutURI RP URL that will cause the RP to log
+                    itself out when sent a Logout Token by the OP
+                  pattern: (^$|^https?://.*)
+                  type: string
+                clientName:
+                  description:
+                    ClientName is the human-readable string name of the client
+                    to be presented to the end-user during authorization.
+                  type: string
+                clientSecretExpiresAt:
+                  description:
+                    ClientSecretExpiresAt is the timestamp when the client
+                    secret expires (currently always 0)
+                  format: int64
+                  minimum: 0
+                  type: integer
+                clientUri:
+                  description:
+                    ClientUri is a URL string of a web page providing
+                    information about the client
+                  pattern: (^$|^https?://.*)
+                  type: string
+                contacts:
+                  description:
+                    Contacts is an array of strings representing ways to contact
+                    people responsible for this client
+                  items:
+                    type: string
+                  type: array
+                deletionPolicy:
+                  description: |-
+                    Indicates if a deleted OAuth2Client custom resource should delete the database row or not.
+                    Values can be 'delete' to delete the OAuth2 client, value 'orphan' to keep an orphan oauth2 client.
+                  enum:
+                    - delete
+                    - orphan
+                  type: string
+                frontChannelLogoutSessionRequired:
+                  default: false
+                  description:
+                    FrontChannelLogoutSessionRequired Boolean value specifying
+                    whether the RP requires that iss (issuer) and sid (session
+                    ID) query parameters be included to identify the RP session
+                    with the OP when the frontchannel_logout_uri is used
+                  type: boolean
+                frontChannelLogoutURI:
+                  description:
+                    FrontChannelLogoutURI RP URL that will cause the RP to log
+                    itself out when rendered in an iframe by the OP. An iss
+                    (issuer) query parameter and a sid (session ID) query
+                    parameter MAY be included by the OP to enable the RP to
+                    validate the request and to determine which of the
+                    potentially multiple sessions is to be logged out; if either
+                    is included, both MUST be
+                  pattern: (^$|^https?://.*)
+                  type: string
+                grantTypes:
+                  description:
+                    GrantTypes is an array of grant types the client is allowed
+                    to use.
+                  items:
+                    description: GrantType represents an OAuth 2.0 grant type
+                    enum:
+                      - client_credentials
+                      - authorization_code
+                      - implicit
+                      - refresh_token
+                    type: string
+                  maxItems: 4
+                  minItems: 1
+                  type: array
+                hydraAdmin:
+                  description: |-
+                    HydraAdmin is the optional configuration to use for managing
+                    this client
+                  properties:
+                    endpoint:
+                      description: |-
+                        Endpoint is the endpoint for the hydra instance on which
+                        to set up the client. This value will override the value
+                        provided to `--endpoint` (defaults to `"/clients"` in the
+                        application)
+                      pattern: (^$|^/.*)
+                      type: string
+                    forwardedProto:
+                      description: |-
+                        ForwardedProto overrides the `--forwarded-proto` flag. The
+                        value "off" will force this to be off even if
+                        `--forwarded-proto` is specified
+                      pattern: (^$|https?|off)
+                      type: string
+                    port:
+                      description: |-
+                        Port is the port for the hydra instance on
+                        which to set up the client. This value will override the value
+                        provided to `--hydra-port`
+                      maximum: 65535
+                      type: integer
+                    url:
+                      description: |-
+                        URL is the URL for the hydra instance on
+                        which to set up the client. This value will override the value
+                        provided to `--hydra-url`
+                      maxLength: 256
+                      pattern: (^$|^https?://.*)
+                      type: string
+                  type: object
+                jwksUri:
+                  description:
+                    JwksUri Define the URL where the JSON Web Key Set should be
+                    fetched from when performing the private_key_jwt client
+                    authentication method.
+                  pattern: (^$|^https?://.*)
+                  type: string
+                logoUri:
+                  description: |-
+                    LogoUri is the URI to the logo of the client.
+                    This is used to display the logo in the consent screen.
+                    It should be a valid URL pointing to an image.
+                  pattern: (^$|^https?://.*)
+                  type: string
+                metadata:
+                  description: Metadata is arbitrary data
+                  nullable: true
+                  type: object
+                  x-kubernetes-preserve-unknown-fields: true
+                policyUri:
+                  description:
+                    PolicyUri is a URL string that points to a human-readable
+                    privacy policy document
+                  pattern: (^$|^https?://.*)
+                  type: string
+                postLogoutRedirectUris:
+                  description:
+                    PostLogoutRedirectURIs is an array of the post logout
+                    redirect URIs allowed for the application
+                  items:
+                    description:
+                      RedirectURI represents a redirect URI for the client
+                    pattern: \w+:/?/?[^\s]+
+                    type: string
+                  type: array
+                redirectUris:
+                  description:
+                    RedirectURIs is an array of the redirect URIs allowed for
+                    the application
+                  items:
+                    description:
+                      RedirectURI represents a redirect URI for the client
+                    pattern: \w+:/?/?[^\s]+
+                    type: string
+                  type: array
+                requestObjectSigningAlg:
+                  description:
+                    RequestObjectSigningAlg is the algorithm that must be used
+                    for signing request objects
+                  type: string
+                requestUris:
+                  description:
+                    RequestURIs is an array of request URIs that can be used in
+                    authorization requests
+                  items:
+                    description:
+                      RedirectURI represents a redirect URI for the client
+                    pattern: \w+:/?/?[^\s]+
+                    type: string
+                  type: array
+                requireExistingSecret:
+                  description: |-
+                    RequireExistingSecret makes the controller wait for the secret referenced by
+                    secretName instead of registering the client with a Hydra-generated secret and
+                    creating that secret itself. Use this when the secret is provisioned by another
+                    controller, e.g. the External Secrets Operator. If unset, the controller-wide
+                    `--require-existing-secret` flag applies.
+                  type: boolean
+                responseTypes:
+                  description: |-
+                    ResponseTypes is an array of the OAuth 2.0 response type strings that the client can
+                    use at the authorization endpoint.
+                  items:
+                    description:
+                      ResponseType represents an OAuth 2.0 response type strings
+                    enum:
+                      - id_token
+                      - code
+                      - token
+                      - code token
+                      - code id_token
+                      - id_token token
+                      - code id_token token
+                    type: string
+                  maxItems: 3
+                  minItems: 1
+                  type: array
+                scope:
+                  description: |-
+                    Scope is a string containing a space-separated list of scope values (as
+                    described in Section 3.3 of OAuth 2.0 [RFC6749]) that the client
+                    can use when requesting access tokens.
+                    Use scopeArray instead.
+                  pattern: ([a-zA-Z0-9\.\*]+\s?)*
+                  type: string
+                scopeArray:
+                  description: |-
+                    Scope is an array of scope values (as described in Section 3.3 of OAuth 2.0 [RFC6749])
+                    that the client can use when requesting access tokens.
+                  items:
+                    type: string
+                  type: array
+                secretName:
+                  description:
+                    SecretName points to the K8s secret that contains this
+                    client's ID and password
+                  maxLength: 253
+                  minLength: 1
+                  pattern: '[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*'
+                  type: string
+                sectorIdentifierUri:
+                  description:
+                    SectorIdentifierUri is a URL using the https scheme to be
+                    used in calculating Pseudonymous Identifiers
+                  pattern: (^$|^https?://.*)
+                  type: string
+                skipConsent:
+                  default: false
+                  description:
+                    SkipConsent skips the consent screen for this client.
+                  type: boolean
+                skipLogoutConsent:
+                  default: false
+                  description:
+                    SkipLogoutConsent skips asking the user to confirm the
+                    logout request
+                  type: boolean
+                subjectType:
+                  description: SubjectType is the requested subject type
+                  enum:
+                    - public
+                    - pairwise
+                  type: string
+                tokenEndpointAuthMethod:
+                  description:
+                    Indication which authentication method should be used for
+                    the token endpoint
+                  enum:
+                    - client_secret_basic
+                    - client_secret_post
+                    - private_key_jwt
+                    - none
+                  type: string
+                tokenEndpointAuthSigningAlg:
+                  description:
+                    TokenEndpointAuthSigningAlg is the algorithm used to sign
+                    JWT tokens for client authentication
+                  type: string
+                tokenLifespans:
+                  description: |-
+                    TokenLifespans is the configuration to use for managing different token lifespans
+                    depending on the used grant type.
+                  properties:
+                    authorization_code_grant_access_token_lifespan:
+                      description: |-
+                        AuthorizationCodeGrantAccessTokenLifespan is the access token lifespan
+                        issued on an authorization_code grant.
+                      pattern: "[0-9]+(ns|us|ms|s|m|h)"
+                      type: string
+                    authorization_code_grant_id_token_lifespan:
+                      description: |-
+                        AuthorizationCodeGrantIdTokenLifespan is the id token lifespan
+                        issued on an authorization_code grant.
+                      pattern: "[0-9]+(ns|us|ms|s|m|h)"
+                      type: string
+                    authorization_code_grant_refresh_token_lifespan:
+                      description: |-
+                        AuthorizationCodeGrantRefreshTokenLifespan is the refresh token lifespan
+                        issued on an authorization_code grant.
+                      pattern: "[0-9]+(ns|us|ms|s|m|h)"
+                      type: string
+                    client_credentials_grant_access_token_lifespan:
+                      description: |-
+                        AuthorizationCodeGrantRefreshTokenLifespan is the access token lifespan
+                        issued on a client_credentials grant.
+                      pattern: "[0-9]+(ns|us|ms|s|m|h)"
+                      type: string
+                    implicit_grant_access_token_lifespan:
+                      description: |-
+                        ImplicitGrantAccessTokenLifespan is the access token lifespan
+                        issued on an implicit grant.
+                      pattern: "[0-9]+(ns|us|ms|s|m|h)"
+                      type: string
+                    implicit_grant_id_token_lifespan:
+                      description: |-
+                        ImplicitGrantIdTokenLifespan is the id token lifespan
+                        issued on an implicit grant.
+                      pattern: "[0-9]+(ns|us|ms|s|m|h)"
+                      type: string
+                    jwt_bearer_grant_access_token_lifespan:
+                      description: |-
+                        JwtBearerGrantAccessTokenLifespan is the access token lifespan
+                        issued on a jwt_bearer grant.
+                      pattern: "[0-9]+(ns|us|ms|s|m|h)"
+                      type: string
+                    refresh_token_grant_access_token_lifespan:
+                      description: |-
+                        RefreshTokenGrantAccessTokenLifespan is the access token lifespan
+                        issued on a refresh_token grant.
+                      pattern: "[0-9]+(ns|us|ms|s|m|h)"
+                      type: string
+                    refresh_token_grant_id_token_lifespan:
+                      description: |-
+                        RefreshTokenGrantIdTokenLifespan is the id token lifespan
+                        issued on a refresh_token grant.
+                      pattern: "[0-9]+(ns|us|ms|s|m|h)"
+                      type: string
+                    refresh_token_grant_refresh_token_lifespan:
+                      description: |-
+                        RefreshTokenGrantRefreshTokenLifespan is the refresh token lifespan
+                        issued on a refresh_token grant.
+                      pattern: "[0-9]+(ns|us|ms|s|m|h)"
+                      type: string
+                  type: object
+                tosUri:
+                  description:
+                    TosUri is a URL string that points to a human-readable terms
+                    of service document
+                  pattern: (^$|^https?://.*)
+                  type: string
+                userinfoSignedResponseAlg:
+                  description:
+                    UserinfoSignedResponseAlg is the algorithm used to sign
+                    UserInfo responses
+                  type: string
+              required:
+                - grantTypes
+                - secretName
+              type: object
+            status:
+              description:
+                OAuth2ClientStatus defines the observed state of OAuth2Client
+              properties:
+                conditions:
+                  items:
+                    description:
+                      OAuth2ClientCondition contains condition information for
+                      an OAuth2Client
+                    properties:
+                      status:
+                        enum:
+                          - "True"
+                          - "False"
+                          - Unknown
+                        type: string
+                      type:
+                        type: string
+                    required:
+                      - status
+                      - type
+                    type: object
+                  type: array
+                observedGeneration:
+                  description:
+                    ObservedGeneration represents the most recent generation
+                    observed by the daemon set controller.
+                  format: int64
+                  type: integer
+                reconciliationError:
+                  description:
+                    ReconciliationError represents an error that occurred during
+                    the reconciliation process
+                  properties:
+                    description:
+                      description:
+                        Description is the description of the reconciliation
+                        error
+                      type: string
+                    statusCode:
+                      description:
+                        Code is the status code of the reconciliation error
+                      type: string
+                  type: object
+              type: object
+          type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}

--- a/config/crd/bases/hydra.ory.sh_oauth2clients.yaml
+++ b/config/crd/bases/hydra.ory.sh_oauth2clients.yaml
@@ -14,441 +14,411 @@ spec:
     singular: oauth2client
   scope: Namespaced
   versions:
-    - name: v1alpha1
-      schema:
-        openAPIV3Schema:
-          description: OAuth2Client is the Schema for the oauth2clients API
-          properties:
-            apiVersion:
-              description: |-
-                APIVersion defines the versioned schema of this representation of an object.
-                Servers should convert recognized schemas to the latest internal value, and
-                may reject unrecognized values.
-                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-              type: string
-            kind:
-              description: |-
-                Kind is a string value representing the REST resource this object represents.
-                Servers may infer this from the endpoint the client submits requests to.
-                Cannot be updated.
-                In CamelCase.
-                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-              type: string
-            metadata:
-              type: object
-            spec:
-              description:
-                OAuth2ClientSpec defines the desired state of OAuth2Client
-              properties:
-                accessTokenStrategy:
-                  description:
-                    AccessTokenStrategy is the OAuth 2.0 Access Token Strategy
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: OAuth2Client is the Schema for the oauth2clients API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: OAuth2ClientSpec defines the desired state of OAuth2Client
+            properties:
+              accessTokenStrategy:
+                description: AccessTokenStrategy is the OAuth 2.0 Access Token Strategy
+                enum:
+                - jwt
+                - opaque
+                type: string
+              allowedCorsOrigins:
+                description: AllowedCorsOrigins is an array of allowed CORS origins
+                items:
+                  description: RedirectURI represents a redirect URI for the client
+                  pattern: \w+:/?/?[^\s]+
+                  type: string
+                type: array
+              audience:
+                description: Audience is a whitelist defining the audiences this client
+                  is allowed to request tokens for
+                items:
+                  type: string
+                type: array
+              backChannelLogoutSessionRequired:
+                default: false
+                description: BackChannelLogoutSessionRequired Boolean value specifying
+                  whether the RP requires that a sid (session ID) Claim be included
+                  in the Logout Token to identify the RP session with the OP when
+                  the backchannel_logout_uri is used. If omitted, the default value
+                  is false.
+                type: boolean
+              backChannelLogoutURI:
+                description: BackChannelLogoutURI RP URL that will cause the RP to
+                  log itself out when sent a Logout Token by the OP
+                pattern: (^$|^https?://.*)
+                type: string
+              clientName:
+                description: ClientName is the human-readable string name of the client
+                  to be presented to the end-user during authorization.
+                type: string
+              clientSecretExpiresAt:
+                description: ClientSecretExpiresAt is the timestamp when the client
+                  secret expires (currently always 0)
+                format: int64
+                minimum: 0
+                type: integer
+              clientUri:
+                description: ClientUri is a URL string of a web page providing information
+                  about the client
+                pattern: (^$|^https?://.*)
+                type: string
+              contacts:
+                description: Contacts is an array of strings representing ways to
+                  contact people responsible for this client
+                items:
+                  type: string
+                type: array
+              deletionPolicy:
+                description: |-
+                  Indicates if a deleted OAuth2Client custom resource should delete the database row or not.
+                  Values can be 'delete' to delete the OAuth2 client, value 'orphan' to keep an orphan oauth2 client.
+                enum:
+                - delete
+                - orphan
+                type: string
+              frontChannelLogoutSessionRequired:
+                default: false
+                description: FrontChannelLogoutSessionRequired Boolean value specifying
+                  whether the RP requires that iss (issuer) and sid (session ID) query
+                  parameters be included to identify the RP session with the OP when
+                  the frontchannel_logout_uri is used
+                type: boolean
+              frontChannelLogoutURI:
+                description: FrontChannelLogoutURI RP URL that will cause the RP to
+                  log itself out when rendered in an iframe by the OP. An iss (issuer)
+                  query parameter and a sid (session ID) query parameter MAY be included
+                  by the OP to enable the RP to validate the request and to determine
+                  which of the potentially multiple sessions is to be logged out;
+                  if either is included, both MUST be
+                pattern: (^$|^https?://.*)
+                type: string
+              grantTypes:
+                description: GrantTypes is an array of grant types the client is allowed
+                  to use.
+                items:
+                  description: GrantType represents an OAuth 2.0 grant type
                   enum:
-                    - jwt
-                    - opaque
+                  - client_credentials
+                  - authorization_code
+                  - implicit
+                  - refresh_token
                   type: string
-                allowedCorsOrigins:
-                  description:
-                    AllowedCorsOrigins is an array of allowed CORS origins
-                  items:
-                    description:
-                      RedirectURI represents a redirect URI for the client
-                    pattern: \w+:/?/?[^\s]+
+                maxItems: 4
+                minItems: 1
+                type: array
+              hydraAdmin:
+                description: |-
+                  HydraAdmin is the optional configuration to use for managing
+                  this client
+                properties:
+                  endpoint:
+                    description: |-
+                      Endpoint is the endpoint for the hydra instance on which
+                      to set up the client. This value will override the value
+                      provided to `--endpoint` (defaults to `"/clients"` in the
+                      application)
+                    pattern: (^$|^/.*)
                     type: string
-                  type: array
-                audience:
-                  description:
-                    Audience is a whitelist defining the audiences this client
-                    is allowed to request tokens for
-                  items:
+                  forwardedProto:
+                    description: |-
+                      ForwardedProto overrides the `--forwarded-proto` flag. The
+                      value "off" will force this to be off even if
+                      `--forwarded-proto` is specified
+                    pattern: (^$|https?|off)
                     type: string
-                  type: array
-                backChannelLogoutSessionRequired:
-                  default: false
-                  description:
-                    BackChannelLogoutSessionRequired Boolean value specifying
-                    whether the RP requires that a sid (session ID) Claim be
-                    included in the Logout Token to identify the RP session with
-                    the OP when the backchannel_logout_uri is used. If omitted,
-                    the default value is false.
-                  type: boolean
-                backChannelLogoutURI:
-                  description:
-                    BackChannelLogoutURI RP URL that will cause the RP to log
-                    itself out when sent a Logout Token by the OP
-                  pattern: (^$|^https?://.*)
-                  type: string
-                clientName:
-                  description:
-                    ClientName is the human-readable string name of the client
-                    to be presented to the end-user during authorization.
-                  type: string
-                clientSecretExpiresAt:
-                  description:
-                    ClientSecretExpiresAt is the timestamp when the client
-                    secret expires (currently always 0)
-                  format: int64
-                  minimum: 0
-                  type: integer
-                clientUri:
-                  description:
-                    ClientUri is a URL string of a web page providing
-                    information about the client
-                  pattern: (^$|^https?://.*)
-                  type: string
-                contacts:
-                  description:
-                    Contacts is an array of strings representing ways to contact
-                    people responsible for this client
-                  items:
+                  port:
+                    description: |-
+                      Port is the port for the hydra instance on
+                      which to set up the client. This value will override the value
+                      provided to `--hydra-port`
+                    maximum: 65535
+                    type: integer
+                  url:
+                    description: |-
+                      URL is the URL for the hydra instance on
+                      which to set up the client. This value will override the value
+                      provided to `--hydra-url`
+                    maxLength: 256
+                    pattern: (^$|^https?://.*)
                     type: string
-                  type: array
-                deletionPolicy:
-                  description: |-
-                    Indicates if a deleted OAuth2Client custom resource should delete the database row or not.
-                    Values can be 'delete' to delete the OAuth2 client, value 'orphan' to keep an orphan oauth2 client.
+                type: object
+              jwksUri:
+                description: JwksUri Define the URL where the JSON Web Key Set should
+                  be fetched from when performing the private_key_jwt client authentication
+                  method.
+                pattern: (^$|^https?://.*)
+                type: string
+              logoUri:
+                description: |-
+                  LogoUri is the URI to the logo of the client.
+                  This is used to display the logo in the consent screen.
+                  It should be a valid URL pointing to an image.
+                pattern: (^$|^https?://.*)
+                type: string
+              metadata:
+                description: Metadata is arbitrary data
+                nullable: true
+                type: object
+                x-kubernetes-preserve-unknown-fields: true
+              policyUri:
+                description: PolicyUri is a URL string that points to a human-readable
+                  privacy policy document
+                pattern: (^$|^https?://.*)
+                type: string
+              postLogoutRedirectUris:
+                description: PostLogoutRedirectURIs is an array of the post logout
+                  redirect URIs allowed for the application
+                items:
+                  description: RedirectURI represents a redirect URI for the client
+                  pattern: \w+:/?/?[^\s]+
+                  type: string
+                type: array
+              redirectUris:
+                description: RedirectURIs is an array of the redirect URIs allowed
+                  for the application
+                items:
+                  description: RedirectURI represents a redirect URI for the client
+                  pattern: \w+:/?/?[^\s]+
+                  type: string
+                type: array
+              requestObjectSigningAlg:
+                description: RequestObjectSigningAlg is the algorithm that must be
+                  used for signing request objects
+                type: string
+              requestUris:
+                description: RequestURIs is an array of request URIs that can be used
+                  in authorization requests
+                items:
+                  description: RedirectURI represents a redirect URI for the client
+                  pattern: \w+:/?/?[^\s]+
+                  type: string
+                type: array
+              requireExistingSecret:
+                description: |-
+                  RequireExistingSecret makes the controller wait for the secret referenced by
+                  secretName instead of registering the client with a Hydra-generated secret and
+                  creating that secret itself. Use this when the secret is provisioned by another
+                  controller, e.g. the External Secrets Operator. If unset, the controller-wide
+                  `--require-existing-secret` flag applies.
+                type: boolean
+              responseTypes:
+                description: |-
+                  ResponseTypes is an array of the OAuth 2.0 response type strings that the client can
+                  use at the authorization endpoint.
+                items:
+                  description: ResponseType represents an OAuth 2.0 response type
+                    strings
                   enum:
-                    - delete
-                    - orphan
+                  - id_token
+                  - code
+                  - token
+                  - code token
+                  - code id_token
+                  - id_token token
+                  - code id_token token
                   type: string
-                frontChannelLogoutSessionRequired:
-                  default: false
-                  description:
-                    FrontChannelLogoutSessionRequired Boolean value specifying
-                    whether the RP requires that iss (issuer) and sid (session
-                    ID) query parameters be included to identify the RP session
-                    with the OP when the frontchannel_logout_uri is used
-                  type: boolean
-                frontChannelLogoutURI:
-                  description:
-                    FrontChannelLogoutURI RP URL that will cause the RP to log
-                    itself out when rendered in an iframe by the OP. An iss
-                    (issuer) query parameter and a sid (session ID) query
-                    parameter MAY be included by the OP to enable the RP to
-                    validate the request and to determine which of the
-                    potentially multiple sessions is to be logged out; if either
-                    is included, both MUST be
-                  pattern: (^$|^https?://.*)
+                maxItems: 3
+                minItems: 1
+                type: array
+              scope:
+                description: |-
+                  Scope is a string containing a space-separated list of scope values (as
+                  described in Section 3.3 of OAuth 2.0 [RFC6749]) that the client
+                  can use when requesting access tokens.
+                  Use scopeArray instead.
+                pattern: ([a-zA-Z0-9\.\*]+\s?)*
+                type: string
+              scopeArray:
+                description: |-
+                  Scope is an array of scope values (as described in Section 3.3 of OAuth 2.0 [RFC6749])
+                  that the client can use when requesting access tokens.
+                items:
                   type: string
-                grantTypes:
-                  description:
-                    GrantTypes is an array of grant types the client is allowed
-                    to use.
-                  items:
-                    description: GrantType represents an OAuth 2.0 grant type
-                    enum:
-                      - client_credentials
-                      - authorization_code
-                      - implicit
-                      - refresh_token
+                type: array
+              secretName:
+                description: SecretName points to the K8s secret that contains this
+                  client's ID and password
+                maxLength: 253
+                minLength: 1
+                pattern: '[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*'
+                type: string
+              sectorIdentifierUri:
+                description: SectorIdentifierUri is a URL using the https scheme to
+                  be used in calculating Pseudonymous Identifiers
+                pattern: (^$|^https?://.*)
+                type: string
+              skipConsent:
+                default: false
+                description: SkipConsent skips the consent screen for this client.
+                type: boolean
+              skipLogoutConsent:
+                default: false
+                description: SkipLogoutConsent skips asking the user to confirm the
+                  logout request
+                type: boolean
+              subjectType:
+                description: SubjectType is the requested subject type
+                enum:
+                - public
+                - pairwise
+                type: string
+              tokenEndpointAuthMethod:
+                description: Indication which authentication method should be used
+                  for the token endpoint
+                enum:
+                - client_secret_basic
+                - client_secret_post
+                - private_key_jwt
+                - none
+                type: string
+              tokenEndpointAuthSigningAlg:
+                description: TokenEndpointAuthSigningAlg is the algorithm used to
+                  sign JWT tokens for client authentication
+                type: string
+              tokenLifespans:
+                description: |-
+                  TokenLifespans is the configuration to use for managing different token lifespans
+                  depending on the used grant type.
+                properties:
+                  authorization_code_grant_access_token_lifespan:
+                    description: |-
+                      AuthorizationCodeGrantAccessTokenLifespan is the access token lifespan
+                      issued on an authorization_code grant.
+                    pattern: '[0-9]+(ns|us|ms|s|m|h)'
                     type: string
-                  maxItems: 4
-                  minItems: 1
-                  type: array
-                hydraAdmin:
-                  description: |-
-                    HydraAdmin is the optional configuration to use for managing
-                    this client
+                  authorization_code_grant_id_token_lifespan:
+                    description: |-
+                      AuthorizationCodeGrantIdTokenLifespan is the id token lifespan
+                      issued on an authorization_code grant.
+                    pattern: '[0-9]+(ns|us|ms|s|m|h)'
+                    type: string
+                  authorization_code_grant_refresh_token_lifespan:
+                    description: |-
+                      AuthorizationCodeGrantRefreshTokenLifespan is the refresh token lifespan
+                      issued on an authorization_code grant.
+                    pattern: '[0-9]+(ns|us|ms|s|m|h)'
+                    type: string
+                  client_credentials_grant_access_token_lifespan:
+                    description: |-
+                      AuthorizationCodeGrantRefreshTokenLifespan is the access token lifespan
+                      issued on a client_credentials grant.
+                    pattern: '[0-9]+(ns|us|ms|s|m|h)'
+                    type: string
+                  implicit_grant_access_token_lifespan:
+                    description: |-
+                      ImplicitGrantAccessTokenLifespan is the access token lifespan
+                      issued on an implicit grant.
+                    pattern: '[0-9]+(ns|us|ms|s|m|h)'
+                    type: string
+                  implicit_grant_id_token_lifespan:
+                    description: |-
+                      ImplicitGrantIdTokenLifespan is the id token lifespan
+                      issued on an implicit grant.
+                    pattern: '[0-9]+(ns|us|ms|s|m|h)'
+                    type: string
+                  jwt_bearer_grant_access_token_lifespan:
+                    description: |-
+                      JwtBearerGrantAccessTokenLifespan is the access token lifespan
+                      issued on a jwt_bearer grant.
+                    pattern: '[0-9]+(ns|us|ms|s|m|h)'
+                    type: string
+                  refresh_token_grant_access_token_lifespan:
+                    description: |-
+                      RefreshTokenGrantAccessTokenLifespan is the access token lifespan
+                      issued on a refresh_token grant.
+                    pattern: '[0-9]+(ns|us|ms|s|m|h)'
+                    type: string
+                  refresh_token_grant_id_token_lifespan:
+                    description: |-
+                      RefreshTokenGrantIdTokenLifespan is the id token lifespan
+                      issued on a refresh_token grant.
+                    pattern: '[0-9]+(ns|us|ms|s|m|h)'
+                    type: string
+                  refresh_token_grant_refresh_token_lifespan:
+                    description: |-
+                      RefreshTokenGrantRefreshTokenLifespan is the refresh token lifespan
+                      issued on a refresh_token grant.
+                    pattern: '[0-9]+(ns|us|ms|s|m|h)'
+                    type: string
+                type: object
+              tosUri:
+                description: TosUri is a URL string that points to a human-readable
+                  terms of service document
+                pattern: (^$|^https?://.*)
+                type: string
+              userinfoSignedResponseAlg:
+                description: UserinfoSignedResponseAlg is the algorithm used to sign
+                  UserInfo responses
+                type: string
+            required:
+            - grantTypes
+            - secretName
+            type: object
+          status:
+            description: OAuth2ClientStatus defines the observed state of OAuth2Client
+            properties:
+              conditions:
+                items:
+                  description: OAuth2ClientCondition contains condition information
+                    for an OAuth2Client
                   properties:
-                    endpoint:
-                      description: |-
-                        Endpoint is the endpoint for the hydra instance on which
-                        to set up the client. This value will override the value
-                        provided to `--endpoint` (defaults to `"/clients"` in the
-                        application)
-                      pattern: (^$|^/.*)
+                    status:
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
                       type: string
-                    forwardedProto:
-                      description: |-
-                        ForwardedProto overrides the `--forwarded-proto` flag. The
-                        value "off" will force this to be off even if
-                        `--forwarded-proto` is specified
-                      pattern: (^$|https?|off)
+                    type:
                       type: string
-                    port:
-                      description: |-
-                        Port is the port for the hydra instance on
-                        which to set up the client. This value will override the value
-                        provided to `--hydra-port`
-                      maximum: 65535
-                      type: integer
-                    url:
-                      description: |-
-                        URL is the URL for the hydra instance on
-                        which to set up the client. This value will override the value
-                        provided to `--hydra-url`
-                      maxLength: 256
-                      pattern: (^$|^https?://.*)
-                      type: string
+                  required:
+                  - status
+                  - type
                   type: object
-                jwksUri:
+                type: array
+              observedGeneration:
+                description: ObservedGeneration represents the most recent generation
+                  observed by the daemon set controller.
+                format: int64
+                type: integer
+              reconciliationError:
+                description: ReconciliationError represents an error that occurred
+                  during the reconciliation process
+                properties:
                   description:
-                    JwksUri Define the URL where the JSON Web Key Set should be
-                    fetched from when performing the private_key_jwt client
-                    authentication method.
-                  pattern: (^$|^https?://.*)
-                  type: string
-                logoUri:
-                  description: |-
-                    LogoUri is the URI to the logo of the client.
-                    This is used to display the logo in the consent screen.
-                    It should be a valid URL pointing to an image.
-                  pattern: (^$|^https?://.*)
-                  type: string
-                metadata:
-                  description: Metadata is arbitrary data
-                  nullable: true
-                  type: object
-                  x-kubernetes-preserve-unknown-fields: true
-                policyUri:
-                  description:
-                    PolicyUri is a URL string that points to a human-readable
-                    privacy policy document
-                  pattern: (^$|^https?://.*)
-                  type: string
-                postLogoutRedirectUris:
-                  description:
-                    PostLogoutRedirectURIs is an array of the post logout
-                    redirect URIs allowed for the application
-                  items:
-                    description:
-                      RedirectURI represents a redirect URI for the client
-                    pattern: \w+:/?/?[^\s]+
+                    description: Description is the description of the reconciliation
+                      error
                     type: string
-                  type: array
-                redirectUris:
-                  description:
-                    RedirectURIs is an array of the redirect URIs allowed for
-                    the application
-                  items:
-                    description:
-                      RedirectURI represents a redirect URI for the client
-                    pattern: \w+:/?/?[^\s]+
+                  statusCode:
+                    description: Code is the status code of the reconciliation error
                     type: string
-                  type: array
-                requestObjectSigningAlg:
-                  description:
-                    RequestObjectSigningAlg is the algorithm that must be used
-                    for signing request objects
-                  type: string
-                requestUris:
-                  description:
-                    RequestURIs is an array of request URIs that can be used in
-                    authorization requests
-                  items:
-                    description:
-                      RedirectURI represents a redirect URI for the client
-                    pattern: \w+:/?/?[^\s]+
-                    type: string
-                  type: array
-                responseTypes:
-                  description: |-
-                    ResponseTypes is an array of the OAuth 2.0 response type strings that the client can
-                    use at the authorization endpoint.
-                  items:
-                    description:
-                      ResponseType represents an OAuth 2.0 response type strings
-                    enum:
-                      - id_token
-                      - code
-                      - token
-                      - code token
-                      - code id_token
-                      - id_token token
-                      - code id_token token
-                    type: string
-                  maxItems: 3
-                  minItems: 1
-                  type: array
-                scope:
-                  description: |-
-                    Scope is a string containing a space-separated list of scope values (as
-                    described in Section 3.3 of OAuth 2.0 [RFC6749]) that the client
-                    can use when requesting access tokens.
-                    Use scopeArray instead.
-                  pattern: ([a-zA-Z0-9\.\*]+\s?)*
-                  type: string
-                scopeArray:
-                  description: |-
-                    Scope is an array of scope values (as described in Section 3.3 of OAuth 2.0 [RFC6749])
-                    that the client can use when requesting access tokens.
-                  items:
-                    type: string
-                  type: array
-                secretName:
-                  description:
-                    SecretName points to the K8s secret that contains this
-                    client's ID and password
-                  maxLength: 253
-                  minLength: 1
-                  pattern: '[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*'
-                  type: string
-                sectorIdentifierUri:
-                  description:
-                    SectorIdentifierUri is a URL using the https scheme to be
-                    used in calculating Pseudonymous Identifiers
-                  pattern: (^$|^https?://.*)
-                  type: string
-                skipConsent:
-                  default: false
-                  description:
-                    SkipConsent skips the consent screen for this client.
-                  type: boolean
-                skipLogoutConsent:
-                  default: false
-                  description:
-                    SkipLogoutConsent skips asking the user to confirm the
-                    logout request
-                  type: boolean
-                subjectType:
-                  description: SubjectType is the requested subject type
-                  enum:
-                    - public
-                    - pairwise
-                  type: string
-                tokenEndpointAuthMethod:
-                  description:
-                    Indication which authentication method should be used for
-                    the token endpoint
-                  enum:
-                    - client_secret_basic
-                    - client_secret_post
-                    - private_key_jwt
-                    - none
-                  type: string
-                tokenEndpointAuthSigningAlg:
-                  description:
-                    TokenEndpointAuthSigningAlg is the algorithm used to sign
-                    JWT tokens for client authentication
-                  type: string
-                tokenLifespans:
-                  description: |-
-                    TokenLifespans is the configuration to use for managing different token lifespans
-                    depending on the used grant type.
-                  properties:
-                    authorization_code_grant_access_token_lifespan:
-                      description: |-
-                        AuthorizationCodeGrantAccessTokenLifespan is the access token lifespan
-                        issued on an authorization_code grant.
-                      pattern: "[0-9]+(ns|us|ms|s|m|h)"
-                      type: string
-                    authorization_code_grant_id_token_lifespan:
-                      description: |-
-                        AuthorizationCodeGrantIdTokenLifespan is the id token lifespan
-                        issued on an authorization_code grant.
-                      pattern: "[0-9]+(ns|us|ms|s|m|h)"
-                      type: string
-                    authorization_code_grant_refresh_token_lifespan:
-                      description: |-
-                        AuthorizationCodeGrantRefreshTokenLifespan is the refresh token lifespan
-                        issued on an authorization_code grant.
-                      pattern: "[0-9]+(ns|us|ms|s|m|h)"
-                      type: string
-                    client_credentials_grant_access_token_lifespan:
-                      description: |-
-                        AuthorizationCodeGrantRefreshTokenLifespan is the access token lifespan
-                        issued on a client_credentials grant.
-                      pattern: "[0-9]+(ns|us|ms|s|m|h)"
-                      type: string
-                    implicit_grant_access_token_lifespan:
-                      description: |-
-                        ImplicitGrantAccessTokenLifespan is the access token lifespan
-                        issued on an implicit grant.
-                      pattern: "[0-9]+(ns|us|ms|s|m|h)"
-                      type: string
-                    implicit_grant_id_token_lifespan:
-                      description: |-
-                        ImplicitGrantIdTokenLifespan is the id token lifespan
-                        issued on an implicit grant.
-                      pattern: "[0-9]+(ns|us|ms|s|m|h)"
-                      type: string
-                    jwt_bearer_grant_access_token_lifespan:
-                      description: |-
-                        JwtBearerGrantAccessTokenLifespan is the access token lifespan
-                        issued on a jwt_bearer grant.
-                      pattern: "[0-9]+(ns|us|ms|s|m|h)"
-                      type: string
-                    refresh_token_grant_access_token_lifespan:
-                      description: |-
-                        RefreshTokenGrantAccessTokenLifespan is the access token lifespan
-                        issued on a refresh_token grant.
-                      pattern: "[0-9]+(ns|us|ms|s|m|h)"
-                      type: string
-                    refresh_token_grant_id_token_lifespan:
-                      description: |-
-                        RefreshTokenGrantIdTokenLifespan is the id token lifespan
-                        issued on a refresh_token grant.
-                      pattern: "[0-9]+(ns|us|ms|s|m|h)"
-                      type: string
-                    refresh_token_grant_refresh_token_lifespan:
-                      description: |-
-                        RefreshTokenGrantRefreshTokenLifespan is the refresh token lifespan
-                        issued on a refresh_token grant.
-                      pattern: "[0-9]+(ns|us|ms|s|m|h)"
-                      type: string
-                  type: object
-                tosUri:
-                  description:
-                    TosUri is a URL string that points to a human-readable terms
-                    of service document
-                  pattern: (^$|^https?://.*)
-                  type: string
-                userinfoSignedResponseAlg:
-                  description:
-                    UserinfoSignedResponseAlg is the algorithm used to sign
-                    UserInfo responses
-                  type: string
-              required:
-                - grantTypes
-                - secretName
-              type: object
-            status:
-              description:
-                OAuth2ClientStatus defines the observed state of OAuth2Client
-              properties:
-                conditions:
-                  items:
-                    description:
-                      OAuth2ClientCondition contains condition information for
-                      an OAuth2Client
-                    properties:
-                      status:
-                        enum:
-                          - "True"
-                          - "False"
-                          - Unknown
-                        type: string
-                      type:
-                        type: string
-                    required:
-                      - status
-                      - type
-                    type: object
-                  type: array
-                observedGeneration:
-                  description:
-                    ObservedGeneration represents the most recent generation
-                    observed by the daemon set controller.
-                  format: int64
-                  type: integer
-                reconciliationError:
-                  description:
-                    ReconciliationError represents an error that occurred during
-                    the reconciliation process
-                  properties:
-                    description:
-                      description:
-                        Description is the description of the reconciliation
-                        error
-                      type: string
-                    statusCode:
-                      description:
-                        Code is the status code of the reconciliation error
-                      type: string
-                  type: object
-              type: object
-          type: object
-      served: true
-      storage: true
-      subresources:
-        status: {}
+                type: object
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/config/samples/hydra_v1alpha1_oauth2client_external_secret.yaml
+++ b/config/samples/hydra_v1alpha1_oauth2client_external_secret.yaml
@@ -1,0 +1,19 @@
+# The secret referenced below is not part of this manifest on purpose: it is
+# provisioned by another controller, e.g. the External Secrets Operator.
+# `requireExistingSecret: true` makes hydra-maester wait for it instead of
+# registering the client with a generated secret and creating the secret itself.
+apiVersion: hydra.ory.sh/v1alpha1
+kind: OAuth2Client
+metadata:
+  name: my-oauth2-client-external-secret
+  namespace: default
+spec:
+  grantTypes:
+    - client_credentials
+  responseTypes:
+    - token
+  scope: "read write"
+  secretName: hydra-client-oauth2-secret
+  requireExistingSecret: true
+  hydraAdmin: {}
+  tokenEndpointAuthMethod: client_secret_basic

--- a/controllers/oauth2client_controller.go
+++ b/controllers/oauth2client_controller.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"os"
 	"sync"
+	"time"
 
 	"github.com/go-logr/logr"
 	apiv1 "k8s.io/api/core/v1"
@@ -28,6 +29,12 @@ const (
 	FinalizerName    = "finalizer.ory.hydra.sh"
 
 	DefaultNamespace = "default"
+
+	// SecretWaitBaseInterval is the delay before the first re-check of a secret that
+	// does not exist yet. Every subsequent re-check doubles the delay, up to
+	// SecretWaitMaxInterval.
+	SecretWaitBaseInterval = 15 * time.Second
+	SecretWaitMaxInterval  = 5 * time.Minute
 )
 
 var (
@@ -58,15 +65,25 @@ type OAuth2ClientReconciler struct {
 	Log                 logr.Logger
 	ControllerNamespace string
 
+	// RequireExistingSecret is the controller-wide default for
+	// OAuth2ClientSpec.RequireExistingSecret.
+	RequireExistingSecret bool
+
 	oauth2Clients       map[clientKey]hydra.Client
 	oauth2ClientFactory OAuth2ClientFactory
 	mu                  sync.Mutex
+
+	// secretWaitAttempts counts, per object, how often we requeued because the
+	// referenced secret did not exist yet. It is only used to compute the backoff.
+	secretWaitAttempts map[types.NamespacedName]int
+	secretWaitMu       sync.Mutex
 }
 
 // Options represent options to pass to the oauth2 client reconciler.
 type Options struct {
-	Namespace           string
-	OAuth2ClientFactory OAuth2ClientFactory
+	Namespace             string
+	OAuth2ClientFactory   OAuth2ClientFactory
+	RequireExistingSecret bool
 }
 
 // Option is a functional option.
@@ -96,6 +113,16 @@ func WithClientFactory(factory OAuth2ClientFactory) Option {
 	}
 }
 
+// WithRequireExistingSecret sets the controller-wide default for whether the
+// controller waits for the secret referenced by an OAuth2Client instead of
+// registering the client with a generated secret and creating the secret itself.
+// Individual resources can override it via `spec.requireExistingSecret`.
+func WithRequireExistingSecret(require bool) Option {
+	return func(o *Options) {
+		o.RequireExistingSecret = require
+	}
+}
+
 // New returns a new Oauth2ClientReconciler.
 func New(c client.Client, hydraClient hydra.Client, log logr.Logger, opts ...Option) *OAuth2ClientReconciler {
 	options := &Options{
@@ -107,12 +134,14 @@ func New(c client.Client, hydraClient hydra.Client, log logr.Logger, opts ...Opt
 	}
 
 	return &OAuth2ClientReconciler{
-		Client:              c,
-		HydraClient:         hydraClient,
-		Log:                 log,
-		ControllerNamespace: options.Namespace,
-		oauth2Clients:       make(map[clientKey]hydra.Client, 0),
-		oauth2ClientFactory: options.OAuth2ClientFactory,
+		Client:                c,
+		HydraClient:           hydraClient,
+		Log:                   log,
+		ControllerNamespace:   options.Namespace,
+		RequireExistingSecret: options.RequireExistingSecret,
+		oauth2Clients:         make(map[clientKey]hydra.Client, 0),
+		oauth2ClientFactory:   options.OAuth2ClientFactory,
+		secretWaitAttempts:    make(map[types.NamespacedName]int),
 	}
 }
 
@@ -126,6 +155,7 @@ func (r *OAuth2ClientReconciler) Reconcile(ctx context.Context, req ctrl.Request
 	var oauth2client hydrav1alpha1.OAuth2Client
 	if err := r.Get(ctx, req.NamespacedName, &oauth2client); err != nil {
 		if apierrs.IsNotFound(err) {
+			r.resetSecretWait(req.NamespacedName)
 			if registerErr := r.unregisterOAuth2Clients(ctx, &oauth2client); registerErr != nil {
 				return ctrl.Result{}, registerErr
 			}
@@ -159,6 +189,7 @@ func (r *OAuth2ClientReconciler) Reconcile(ctx context.Context, req ctrl.Request
 		}
 	} else {
 		// The object is being deleted
+		r.resetSecretWait(req.NamespacedName)
 		if containsString(oauth2client.ObjectMeta.Finalizers, FinalizerName) {
 			// our finalizer is present, so lets handle any external dependency
 			if err := r.unregisterOAuth2Clients(ctx, &oauth2client); err != nil {
@@ -181,6 +212,12 @@ func (r *OAuth2ClientReconciler) Reconcile(ctx context.Context, req ctrl.Request
 	var secret apiv1.Secret
 	if err := r.Get(ctx, types.NamespacedName{Name: oauth2client.Spec.SecretName, Namespace: req.Namespace}, &secret); err != nil {
 		if apierrs.IsNotFound(err) {
+			if r.requireExistingSecret(&oauth2client) {
+				// The secret is managed outside of this controller and has not been
+				// created yet. Wait for it instead of registering the client with a
+				// generated secret and creating the secret ourselves.
+				return r.waitForSecret(ctx, &oauth2client, req.NamespacedName)
+			}
 			if registerErr := r.registerOAuth2Client(ctx, &oauth2client, nil); registerErr != nil {
 				return ctrl.Result{}, registerErr
 			}
@@ -188,6 +225,7 @@ func (r *OAuth2ClientReconciler) Reconcile(ctx context.Context, req ctrl.Request
 		}
 		return ctrl.Result{}, err
 	}
+	r.resetSecretWait(req.NamespacedName)
 
 	credentials, err := parseSecret(secret, oauth2client.Spec.TokenEndpointAuthMethod)
 	if err != nil {
@@ -248,6 +286,68 @@ func (r *OAuth2ClientReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&hydrav1alpha1.OAuth2Client{}).
 		Complete(r)
+}
+
+// requireExistingSecret reports whether the referenced secret has to exist before
+// the client is registered in hydra. The value on the resource takes precedence
+// over the controller-wide default.
+func (r *OAuth2ClientReconciler) requireExistingSecret(c *hydrav1alpha1.OAuth2Client) bool {
+	if c.Spec.RequireExistingSecret != nil {
+		return *c.Spec.RequireExistingSecret
+	}
+	return r.RequireExistingSecret
+}
+
+// waitForSecret marks the client as not ready and requeues it with an exponential
+// backoff, so that reconciliation resumes once the referenced secret shows up.
+func (r *OAuth2ClientReconciler) waitForSecret(ctx context.Context, c *hydrav1alpha1.OAuth2Client, key types.NamespacedName) (ctrl.Result, error) {
+	requeueAfter := r.nextSecretWaitInterval(key)
+
+	r.Log.Info(
+		fmt.Sprintf("secret %s/%s does not exist yet, waiting for it before registering the client", c.Namespace, c.Spec.SecretName),
+		"oauth2client", fmt.Sprintf("%s/%s", c.Namespace, c.Name),
+		"requeueAfter", requeueAfter.String(),
+	)
+
+	err := fmt.Errorf("secret %s/%s does not exist", c.Namespace, c.Spec.SecretName)
+	if updateErr := r.updateReconciliationStatusPending(ctx, c, hydrav1alpha1.StatusSecretNotFound, err); updateErr != nil {
+		return ctrl.Result{}, updateErr
+	}
+
+	return ctrl.Result{RequeueAfter: requeueAfter}, nil
+}
+
+// nextSecretWaitInterval returns the backoff for the next re-check of a missing
+// secret, doubling on every consecutive attempt up to SecretWaitMaxInterval.
+func (r *OAuth2ClientReconciler) nextSecretWaitInterval(key types.NamespacedName) time.Duration {
+	r.secretWaitMu.Lock()
+	defer r.secretWaitMu.Unlock()
+
+	if r.secretWaitAttempts == nil {
+		r.secretWaitAttempts = make(map[types.NamespacedName]int)
+	}
+
+	attempt := r.secretWaitAttempts[key]
+	r.secretWaitAttempts[key] = attempt + 1
+
+	interval := SecretWaitBaseInterval
+	for i := 0; i < attempt; i++ {
+		interval *= 2
+		if interval >= SecretWaitMaxInterval {
+			return SecretWaitMaxInterval
+		}
+	}
+
+	return interval
+}
+
+// resetSecretWait drops the backoff state for a client that is no longer waiting
+// for its secret.
+func (r *OAuth2ClientReconciler) resetSecretWait(key types.NamespacedName) {
+	r.secretWaitMu.Lock()
+	defer r.secretWaitMu.Unlock()
+
+	delete(r.secretWaitAttempts, key)
 }
 
 func (r *OAuth2ClientReconciler) registerOAuth2Client(ctx context.Context, c *hydrav1alpha1.OAuth2Client, credentials *hydra.Oauth2ClientCredentials) error {
@@ -394,6 +494,32 @@ func (r *OAuth2ClientReconciler) updateReconciliationStatusError(ctx context.Con
 	}
 
 	return err
+}
+
+// updateReconciliationStatusPending reports that reconciliation has not finished
+// yet and will be retried. Unlike updateReconciliationStatusError it leaves
+// ObservedGeneration untouched, so the current generation is still reconciled
+// from scratch once the blocker is gone.
+func (r *OAuth2ClientReconciler) updateReconciliationStatusPending(ctx context.Context, c *hydrav1alpha1.OAuth2Client, code hydrav1alpha1.StatusCode, err error) error {
+	_, updateErr := controllerutil.CreateOrPatch(ctx, r.Client, c, func() error {
+		c.Status.ReconciliationError = hydrav1alpha1.ReconciliationError{
+			Code:        code,
+			Description: err.Error(),
+		}
+		c.Status.Conditions = []hydrav1alpha1.OAuth2ClientCondition{
+			{
+				Type:   hydrav1alpha1.OAuth2ClientConditionReady,
+				Status: hydrav1alpha1.ConditionFalse,
+			},
+		}
+
+		return nil
+	})
+	if updateErr != nil {
+		r.Log.Error(updateErr, fmt.Sprintf("status update failed for client %s/%s ", c.Name, c.Namespace), "oauth2client", "update status")
+	}
+
+	return updateErr
 }
 
 func (r *OAuth2ClientReconciler) ensureEmptyStatusError(ctx context.Context, c *hydrav1alpha1.OAuth2Client) error {

--- a/controllers/oauth2client_controller_integration_test.go
+++ b/controllers/oauth2client_controller_integration_test.go
@@ -800,6 +800,319 @@ var _ = Describe("OAuth2Client Controller", func() {
 			})
 		})
 	})
+
+	Context("when the referenced secret is managed externally", func() {
+
+		It("wait for the secret instead of creating the client, if requireExistingSecret is set on the resource", func() {
+			tstName, tstClientID, tstSecretName := "test-require-existing-secret", "testClientID-require-existing-secret", "my-secret-external"
+			expectedRequest := &reconcile.Request{NamespacedName: types.NamespacedName{Name: tstName, Namespace: tstNamespace}}
+
+			s := runtime.NewScheme()
+			err := hydrav1alpha1.AddToScheme(s)
+			Expect(err).NotTo(HaveOccurred())
+
+			err = apiv1.AddToScheme(s)
+			Expect(err).NotTo(HaveOccurred())
+
+			mgr, err := manager.New(cfg, manager.Options{
+				Scheme: s,
+				Metrics: server.Options{
+					BindAddress: ":8090",
+				},
+			})
+			Expect(err).NotTo(HaveOccurred())
+			c := mgr.GetClient()
+
+			// The manager watches all namespaces, so it also reconciles the clients
+			// left behind by other specs. Only count posts for the client under test.
+			tstOwner := fmt.Sprintf("%s/%s", tstName, tstNamespace)
+			postHasHappened := false
+			mch := &mocks.Client{}
+			mch.On("GetOAuth2Client", Anything).Return(nil, false, nil)
+			mch.On("DeleteOAuth2Client", Anything).Return(nil)
+			mch.On("ListOAuth2Client", Anything).Return(nil, nil)
+			mch.On("PostOAuth2Client", AnythingOfType("*hydra.OAuth2ClientJSON")).Return(func(o *hydra.OAuth2ClientJSON) *hydra.OAuth2ClientJSON {
+				if o.Owner == tstOwner {
+					postHasHappened = true
+				}
+				return &hydra.OAuth2ClientJSON{
+					ClientID:      &tstClientID,
+					Secret:        ptr.To(tstSecret),
+					GrantTypes:    o.GrantTypes,
+					ResponseTypes: o.ResponseTypes,
+					RedirectURIs:  o.RedirectURIs,
+					Scope:         o.Scope,
+					Audience:      o.Audience,
+					Owner:         o.Owner,
+				}
+			}, func(o *hydra.OAuth2ClientJSON) error {
+				return nil
+			})
+
+			recFn, requests := SetupTestReconcile(getAPIReconciler(mgr, mch))
+			Expect(add(mgr, recFn)).To(Succeed())
+
+			stopMgr := StartTestManager(mgr)
+
+			instance := testInstance(tstName, tstSecretName)
+			instance.Spec.RequireExistingSecret = ptr.To(true)
+			err = c.Create(context.TODO(), instance)
+			if apierrors.IsInvalid(err) {
+				Fail(fmt.Sprintf("failed to create object, got an invalid object error: %v", err))
+				return
+			}
+			Expect(err).NotTo(HaveOccurred())
+			Eventually(requests, timeout).Should(Receive(Equal(*expectedRequest)))
+
+			// The client must not have been registered in hydra ...
+			Expect(postHasHappened).To(BeFalse())
+
+			// ... and no secret must have been created for it.
+			var createdSecret apiv1.Secret
+			ok := client.ObjectKey{Name: tstSecretName, Namespace: tstNamespace}
+			err = k8sClient.Get(context.TODO(), ok, &createdSecret)
+			Expect(apierrors.IsNotFound(err)).To(BeTrue())
+
+			// The resource reports that it is waiting for the secret.
+			var retrieved hydrav1alpha1.OAuth2Client
+			ok = client.ObjectKey{Name: tstName, Namespace: tstNamespace}
+			Eventually(func() hydrav1alpha1.StatusCode {
+				if err := c.Get(context.TODO(), ok, &retrieved); err != nil {
+					return ""
+				}
+				return retrieved.Status.ReconciliationError.Code
+			}, timeout).Should(Equal(hydrav1alpha1.StatusSecretNotFound))
+			Expect(retrieved.Status.Conditions).To(ContainElement(hydrav1alpha1.OAuth2ClientCondition{
+				Type:   hydrav1alpha1.OAuth2ClientConditionReady,
+				Status: hydrav1alpha1.ConditionFalse,
+			}))
+			// ObservedGeneration stays behind, so the generation is reconciled in
+			// full once the secret shows up.
+			Expect(retrieved.Status.ObservedGeneration).NotTo(Equal(retrieved.Generation))
+
+			c.Delete(context.TODO(), instance)
+			stopMgr.Done()
+		})
+
+		It("use the externally provided secret once it appears", func() {
+			tstName, tstClientID, tstSecretName := "test-external-secret-appears", "testClientID-external-appears", "my-secret-external-appears"
+			expectedRequest := &reconcile.Request{NamespacedName: types.NamespacedName{Name: tstName, Namespace: tstNamespace}}
+
+			s := runtime.NewScheme()
+			err := hydrav1alpha1.AddToScheme(s)
+			Expect(err).NotTo(HaveOccurred())
+
+			err = apiv1.AddToScheme(s)
+			Expect(err).NotTo(HaveOccurred())
+
+			mgr, err := manager.New(cfg, manager.Options{
+				Scheme: s,
+				Metrics: server.Options{
+					BindAddress: ":8091",
+				},
+			})
+			Expect(err).NotTo(HaveOccurred())
+			c := mgr.GetClient()
+
+			// The manager watches all namespaces, so it also reconciles the clients
+			// left behind by other specs. Only record the client under test.
+			tstOwner := fmt.Sprintf("%s/%s", tstName, tstNamespace)
+			var createdClient *hydra.OAuth2ClientJSON
+			mch := &mocks.Client{}
+			mch.On("GetOAuth2Client", Anything).Return(nil, false, nil)
+			mch.On("DeleteOAuth2Client", Anything).Return(nil)
+			mch.On("ListOAuth2Client", Anything).Return(nil, nil)
+			mch.On("PostOAuth2Client", AnythingOfType("*hydra.OAuth2ClientJSON")).Return(func(o *hydra.OAuth2ClientJSON) *hydra.OAuth2ClientJSON {
+				posted := &hydra.OAuth2ClientJSON{
+					ClientID:      o.ClientID,
+					Secret:        o.Secret,
+					GrantTypes:    o.GrantTypes,
+					ResponseTypes: o.ResponseTypes,
+					RedirectURIs:  o.RedirectURIs,
+					Scope:         o.Scope,
+					Audience:      o.Audience,
+					Owner:         o.Owner,
+				}
+				if o.Owner == tstOwner {
+					createdClient = posted
+				}
+				return posted
+			}, func(o *hydra.OAuth2ClientJSON) error {
+				return nil
+			})
+
+			recFn, requests := SetupTestReconcile(getAPIReconciler(mgr, mch))
+			Expect(add(mgr, recFn)).To(Succeed())
+
+			stopMgr := StartTestManager(mgr)
+
+			instance := testInstance(tstName, tstSecretName)
+			instance.Spec.RequireExistingSecret = ptr.To(true)
+			err = c.Create(context.TODO(), instance)
+			Expect(err).NotTo(HaveOccurred())
+			Eventually(requests, timeout).Should(Receive(Equal(*expectedRequest)))
+			Expect(createdClient).To(BeNil())
+
+			// The external controller materializes the secret.
+			secret := apiv1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      tstSecretName,
+					Namespace: tstNamespace,
+				},
+				Data: map[string][]byte{
+					controllers.ClientIDKey:     []byte(tstClientID),
+					controllers.ClientSecretKey: []byte(tstSecret),
+				},
+			}
+			err = c.Create(context.TODO(), &secret)
+			Expect(err).NotTo(HaveOccurred())
+
+			// Touch the resource so the pending client is reconciled again without
+			// having to wait for the backoff to elapse.
+			var pending hydrav1alpha1.OAuth2Client
+			ok := client.ObjectKey{Name: tstName, Namespace: tstNamespace}
+			Expect(c.Get(context.TODO(), ok, &pending)).To(Succeed())
+			pending.Spec.ClientName = "triggers-a-new-reconciliation"
+			Expect(c.Update(context.TODO(), &pending)).To(Succeed())
+			Eventually(requests, timeout).Should(Receive(Equal(*expectedRequest)))
+
+			// The client is registered with the externally provided credentials.
+			Eventually(func() *hydra.OAuth2ClientJSON {
+				return createdClient
+			}, timeout).ShouldNot(BeNil())
+			Expect(*createdClient.ClientID).To(Equal(tstClientID))
+			Expect(*createdClient.Secret).To(Equal(tstSecret))
+
+			var retrieved hydrav1alpha1.OAuth2Client
+			Eventually(func() hydrav1alpha1.StatusCode {
+				if err := c.Get(context.TODO(), ok, &retrieved); err != nil {
+					return "unknown"
+				}
+				return retrieved.Status.ReconciliationError.Code
+			}, timeout).Should(BeEmpty())
+
+			// The secret is left alone, in particular no owner reference is added.
+			secretKey := client.ObjectKey{Name: tstSecretName, Namespace: tstNamespace}
+			Expect(k8sClient.Get(context.TODO(), secretKey, &secret)).To(Succeed())
+			Expect(secret.OwnerReferences).To(BeEmpty())
+
+			c.Delete(context.TODO(), instance)
+			stopMgr.Done()
+		})
+
+		It("wait for the secret if the controller-wide default is set", func() {
+			tstName, tstSecretName := "test-require-existing-secret-global", "my-secret-external-global"
+			expectedRequest := &reconcile.Request{NamespacedName: types.NamespacedName{Name: tstName, Namespace: tstNamespace}}
+
+			s := runtime.NewScheme()
+			err := hydrav1alpha1.AddToScheme(s)
+			Expect(err).NotTo(HaveOccurred())
+
+			err = apiv1.AddToScheme(s)
+			Expect(err).NotTo(HaveOccurred())
+
+			mgr, err := manager.New(cfg, manager.Options{
+				Scheme: s,
+				Metrics: server.Options{
+					BindAddress: ":8092",
+				},
+			})
+			Expect(err).NotTo(HaveOccurred())
+			c := mgr.GetClient()
+
+			tstOwner := fmt.Sprintf("%s/%s", tstName, tstNamespace)
+			postHasHappened := false
+			mch := &mocks.Client{}
+			mch.On("GetOAuth2Client", Anything).Return(nil, false, nil)
+			mch.On("DeleteOAuth2Client", Anything).Return(nil)
+			mch.On("ListOAuth2Client", Anything).Return(nil, nil)
+			mch.On("PostOAuth2Client", AnythingOfType("*hydra.OAuth2ClientJSON")).Return(func(o *hydra.OAuth2ClientJSON) *hydra.OAuth2ClientJSON {
+				if o.Owner == tstOwner {
+					postHasHappened = true
+				}
+				return &hydra.OAuth2ClientJSON{ClientID: o.ClientID, Secret: o.Secret, Owner: o.Owner}
+			}, func(o *hydra.OAuth2ClientJSON) error {
+				return nil
+			})
+
+			recFn, requests := SetupTestReconcile(getAPIReconciler(mgr, mch, controllers.WithRequireExistingSecret(true)))
+			Expect(add(mgr, recFn)).To(Succeed())
+
+			stopMgr := StartTestManager(mgr)
+
+			// No spec.requireExistingSecret, so the controller-wide default applies.
+			instance := testInstance(tstName, tstSecretName)
+			err = c.Create(context.TODO(), instance)
+			Expect(err).NotTo(HaveOccurred())
+			Eventually(requests, timeout).Should(Receive(Equal(*expectedRequest)))
+
+			Expect(postHasHappened).To(BeFalse())
+
+			var createdSecret apiv1.Secret
+			ok := client.ObjectKey{Name: tstSecretName, Namespace: tstNamespace}
+			err = k8sClient.Get(context.TODO(), ok, &createdSecret)
+			Expect(apierrors.IsNotFound(err)).To(BeTrue())
+
+			c.Delete(context.TODO(), instance)
+			stopMgr.Done()
+		})
+
+		It("create the secret if requireExistingSecret opts out of the controller-wide default", func() {
+			tstName, tstClientID, tstSecretName := "test-require-existing-secret-optout", "testClientID-optout", "my-secret-optout"
+			expectedRequest := &reconcile.Request{NamespacedName: types.NamespacedName{Name: tstName, Namespace: tstNamespace}}
+
+			s := runtime.NewScheme()
+			err := hydrav1alpha1.AddToScheme(s)
+			Expect(err).NotTo(HaveOccurred())
+
+			err = apiv1.AddToScheme(s)
+			Expect(err).NotTo(HaveOccurred())
+
+			mgr, err := manager.New(cfg, manager.Options{
+				Scheme: s,
+				Metrics: server.Options{
+					BindAddress: ":8093",
+				},
+			})
+			Expect(err).NotTo(HaveOccurred())
+			c := mgr.GetClient()
+
+			mch := &mocks.Client{}
+			mch.On("GetOAuth2Client", Anything).Return(nil, false, nil)
+			mch.On("DeleteOAuth2Client", Anything).Return(nil)
+			mch.On("ListOAuth2Client", Anything).Return(nil, nil)
+			mch.On("PostOAuth2Client", AnythingOfType("*hydra.OAuth2ClientJSON")).Return(func(o *hydra.OAuth2ClientJSON) *hydra.OAuth2ClientJSON {
+				return &hydra.OAuth2ClientJSON{
+					ClientID: &tstClientID,
+					Secret:   ptr.To(tstSecret),
+					Owner:    o.Owner,
+				}
+			}, func(o *hydra.OAuth2ClientJSON) error {
+				return nil
+			})
+
+			recFn, requests := SetupTestReconcile(getAPIReconciler(mgr, mch, controllers.WithRequireExistingSecret(true)))
+			Expect(add(mgr, recFn)).To(Succeed())
+
+			stopMgr := StartTestManager(mgr)
+
+			instance := testInstance(tstName, tstSecretName)
+			instance.Spec.RequireExistingSecret = ptr.To(false)
+			err = c.Create(context.TODO(), instance)
+			Expect(err).NotTo(HaveOccurred())
+			Eventually(requests, timeout).Should(Receive(Equal(*expectedRequest)))
+
+			var createdSecret apiv1.Secret
+			ok := client.ObjectKey{Name: tstSecretName, Namespace: tstNamespace}
+			Eventually(func() error {
+				return k8sClient.Get(context.TODO(), ok, &createdSecret)
+			}, timeout).Should(Succeed())
+			Expect(createdSecret.Data[controllers.ClientIDKey]).To(Equal([]byte(tstClientID)))
+
+			c.Delete(context.TODO(), instance)
+			stopMgr.Done()
+		})
+	})
 })
 
 func getOwnerReferenceTo(c hydrav1alpha1.OAuth2Client) []metav1.OwnerReference {
@@ -829,7 +1142,7 @@ func add(mgr manager.Manager, r reconcile.Reconciler) error {
 	return nil
 }
 
-func getAPIReconciler(mgr ctrl.Manager, mock hydra.Client) reconcile.Reconciler {
+func getAPIReconciler(mgr ctrl.Manager, mock hydra.Client, opts ...controllers.Option) reconcile.Reconciler {
 	clientMocker := func(spec hydrav1alpha1.OAuth2ClientSpec, tlsTrustStore string, insecureSkipVerify bool) (hydra.Client, error) {
 		return mock, nil
 	}
@@ -838,7 +1151,7 @@ func getAPIReconciler(mgr ctrl.Manager, mock hydra.Client) reconcile.Reconciler 
 		mgr.GetClient(),
 		mock,
 		ctrl.Log.WithName("controllers").WithName("OAuth2Client"),
-		controllers.WithClientFactory(clientMocker),
+		append([]controllers.Option{controllers.WithClientFactory(clientMocker)}, opts...)...,
 	)
 }
 

--- a/main.go
+++ b/main.go
@@ -7,6 +7,7 @@ import (
 	"flag"
 	"fmt"
 	"os"
+	"strconv"
 	"time"
 
 	"sigs.k8s.io/controller-runtime/pkg/cache"
@@ -36,11 +37,28 @@ func init() {
 	// +kubebuilder:scaffold:scheme
 }
 
+// envBool reads a boolean environment variable, falling back to def if the
+// variable is unset or cannot be parsed.
+func envBool(name string, def bool) bool {
+	value, ok := os.LookupEnv(name)
+	if !ok {
+		return def
+	}
+
+	parsed, err := strconv.ParseBool(value)
+	if err != nil {
+		setupLog.Error(err, "cannot parse environment variable, using default", "variable", name, "value", value, "default", def)
+		return def
+	}
+
+	return parsed
+}
+
 func main() {
 	var (
 		metricsAddr, hydraURL, endpoint, forwardedProto, syncPeriod, tlsTrustStore, namespace, leaderElectorNs string
 		hydraPort                                                                                              int
-		enableLeaderElection, insecureSkipVerify                                                               bool
+		enableLeaderElection, insecureSkipVerify, requireExistingSecret                                        bool
 	)
 
 	flag.StringVar(&metricsAddr, "metrics-addr", ":8080", "The address the metric endpoint binds to.")
@@ -54,6 +72,7 @@ func main() {
 	flag.BoolVar(&insecureSkipVerify, "insecure-skip-verify", false, "If set, http client will be configured to skip insecure verification to connect with hydra admin")
 	flag.StringVar(&namespace, "namespace", "", "Namespace in which the controller should operate. Setting this will make the controller ignore other namespaces.")
 	flag.StringVar(&leaderElectorNs, "leader-elector-namespace", "", "Leader elector namespace where controller should be set.")
+	flag.BoolVar(&requireExistingSecret, "require-existing-secret", envBool("REQUIRE_EXISTING_SECRET", false), "If set, the controller waits for the secret referenced by an OAuth2Client instead of registering the client with a generated secret and creating that secret itself. Can be overridden per resource with spec.requireExistingSecret.")
 	flag.Parse()
 
 	ctrl.SetLogger(zap.New(zap.UseDevMode(true)))
@@ -115,6 +134,7 @@ func main() {
 		hydraClient,
 		ctrl.Log.WithName("controllers").WithName("OAuth2Client"),
 		controllers.WithNamespace(namespace),
+		controllers.WithRequireExistingSecret(requireExistingSecret),
 	).SetupWithManager(mgr)
 	if err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "OAuth2Client")


### PR DESCRIPTION
<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.

This text will be included in the changelog. If applicable, include links to documentation or pieces of code.
If your change includes breaking changes please add a code block documenting the breaking change:

```
BREAKING CHANGES: This patch changes the behavior of configuration item `foo` to do bar. To keep the existing
behavior please do baz.
```
-->

Adds an opt-in option to wait for the Secret referenced by `spec.secretName`
instead of registering the OAuth2 client with a Hydra-generated secret and
creating that Secret itself.

**Why.** When `spec.secretName` points at an externally managed Secret — one
produced by the External Secrets Operator, sealed-secrets, or any other
controller syncing it from a vault — the current "secret not found" branch in
[`controllers/oauth2client_controller.go`](controllers/oauth2client_controller.go)
loses a race. If the `OAuth2Client` reconciles before the Secret has been
materialized, hydra-maester registers the client in Hydra with a **random**
secret and creates its own Secret with an `OwnerReference`. The external
controller then either refuses to adopt that pre-existing, unmanaged Secret
(External Secrets Operator with `creationPolicy: Owner`) or ends up disagreeing
with the value Hydra holds. The end state depends purely on which controller
wins the race.

**What.** The behavior is available controller-wide and per resource.

Controller-wide, via a new flag that also reads from an environment variable:

```
--require-existing-secret        # or REQUIRE_EXISTING_SECRET=true
```

Per resource, via `spec.requireExistingSecret`, which overrides the
controller-wide default in both directions — a resource can opt in while the
controller default is off, and opt out while it is on:

```yaml
apiVersion: hydra.ory.sh/v1alpha1
kind: OAuth2Client
spec:
  secretName: hydra-client-oauth2-secret
  # if true and the secret does not exist yet, requeue instead of
  # registering the client with a generated secret
  requireExistingSecret: true
```

While the referenced Secret is missing, the controller does not register the
client in Hydra, does not create a Secret, reports a pending condition, and
requeues with an exponential backoff (15s, doubling, capped at 5m):

```yaml
status:
  conditions:
    - type: Ready
      status: "False"
  reconciliationError:
    statusCode: SECRET_NOT_FOUND
    description: secret my-namespace/hydra-client-oauth2-secret does not exist
```

Once the Secret appears, reconciliation proceeds normally: the client is
registered with the externally provided `CLIENT_ID` / `CLIENT_SECRET`, and the
Secret is left untouched — in particular no `OwnerReference` is added to it.

No breaking changes. The flag defaults to `false` and the spec field is
optional, so without any configuration the controller behaves exactly as before.
Documented in the
[Externally managed secrets](README.md#externally-managed-secrets) section of
the README.

## Related Issue or Design Document

<!--
If this pull request

1. is a fix for a known bug, link the issue where the bug was reported in the format of `#1234`;
2. is a fix for a previously unknown bug, explain the bug and how to reproduce it in this pull request;
3. implements a new feature, link the issue containing the design document in the format of `#1234`;
4. improves the documentation, no issue reference is required.

Pull requests introducing new features, which do not have a design document linked are more likely to be rejected and take on average 2-8 weeks longer to
get merged.

You can discuss changes with maintainers either in the Github Discussions in this repository or
join the [Ory Chat](https://www.ory.com/chat).
-->

Fixes #294 Fixes #304

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md)
      and signed the CLA.
- [x] I have referenced an issue containing the design document if my change
      introduces a new feature.
- [x] I have read the [security policy](../security/policy).
- [x] I confirm that this pull request does not address a security
      vulnerability. If this pull request addresses a security vulnerability, I
      confirm that I got approval (please contact
      [security@ory.com](mailto:security@ory.com)) from the maintainers to push
      the changes.
- [x] I have added tests that prove my fix is effective or that my feature
      works.
- [x] I have added the necessary documentation within the code base (if
      appropriate).

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution
you did and what alternatives you considered, etc...
-->

### Design decisions

- **Both a flag and a spec field.** The linked issue proposed either one. A
  controller-level switch fits operators who run hydra-maester exclusively in a
  bring-your-own-secret setup, while the per-resource field is needed for mixed
  clusters. Making `spec.requireExistingSecret` a `*bool` keeps "unset"
  distinguishable from "explicitly false", so a single resource can opt out of a
  globally enabled default.
- **`ObservedGeneration` is deliberately left untouched while pending.** Unlike
  `updateReconciliationStatusError`, the new pending-status writer does not
  advance it. Otherwise a client that goes pending and then receives its Secret
  could hit the `Generation == ObservedGeneration` short-circuit in `Reconcile`
  and stay `Ready=False` forever.
- **Explicit `RequeueAfter` instead of the workqueue rate limiter.**
  `Result.Requeue` is deprecated in controller-runtime v0.24, and returning an
  error to get the built-in backoff would log an expected pending state at error
  level on every attempt. The attempt counter is tracked per object and cleared
  as soon as the Secret is found or the object is deleted.

### Alternatives considered

- **Watching Secrets** and enqueuing the referencing `OAuth2Client`. This would
  make pickup immediate rather than bounded by the backoff (up to 5 minutes in
  the worst case), and costs little, since the manager cache already runs a
  Secret informer for the existing `r.Get` on secrets. It was left out because
  it changes reconcile triggers for every user, not just those who opt in. Happy
  to add it if maintainers prefer that.
- **Enforcing ordering externally** (ArgoCD sync-waves, Helm pre-install hooks).
  Brittle, tool-specific, and no protection against re-creation or drift after
  the initial apply.

### Changes

| File                                                              | Change                                                                                              |
| ----------------------------------------------------------------- | --------------------------------------------------------------------------------------------------- |
| `api/v1alpha1/oauth2client_types.go`                              | new `StatusSecretNotFound` status code and `spec.requireExistingSecret` field                       |
| `api/v1alpha1/zz_generated.deepcopy.go`                           | regenerated                                                                                         |
| `config/crd/bases/hydra.ory.sh_oauth2clients.yaml`                | regenerated                                                                                         |
| `controllers/oauth2client_controller.go`                          | `WithRequireExistingSecret` option, wait-and-requeue branch, backoff tracking, pending-status write |
| `main.go`                                                         | `--require-existing-secret` flag, defaulting from `REQUIRE_EXISTING_SECRET`                         |
| `README.md`                                                       | flag/env var tables and an "Externally managed secrets" section                                     |
| `config/samples/hydra_v1alpha1_oauth2client_external_secret.yaml` | sample manifest                                                                                     |

### Tests

Four new integration specs in
`controllers/oauth2client_controller_integration_test.go`:

1. resource-level opt-in → no client registered, no Secret created, status
   reports `SECRET_NOT_FOUND` with `Ready=False`, `ObservedGeneration` stays
   behind
2. Secret appears later → client registered with the externally provided
   credentials, Secret left without an `OwnerReference`
3. controller-wide default → applies to resources that do not set the field
4. per-resource opt-out → Secret is created as before, even with the
   controller-wide default enabled

`make test` passes: 13 specs, all green.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for externally managed OAuth2 client Secrets.
  * Resources can wait for a pre-provisioned Secret before registration and report a pending status when it is missing.
  * Added controller-wide configuration through `REQUIRE_EXISTING_SECRET`, with per-resource overrides.
  * Missing Secrets are retried automatically with capped exponential backoff.
  * Existing Secrets are used without generating or creating replacement Secrets.
  * Added configuration documentation and an example manifest.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->